### PR TITLE
fix: /api/installers 返回 cmd + type 字段

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -48,14 +48,19 @@ function serveHttp() {
     // Installer list
     if (pathname === '/api/installers') {
       const all = getInstallers();
-      const payload = all.map(i => ({
-        id: i.id,
-        name: i.name,
-        description: i.description,
-        icon: i.icon,
-        needsAdmin: i.needsAdmin,
-        installed: i.installed === undefined ? false : i.installed,
-      }));
+      const payload = all.map(i => {
+        const allowed = ALLOWED_COMMANDS[i.id];
+        return {
+          id: i.id,
+          name: i.name,
+          description: i.description,
+          icon: i.icon,
+          needsAdmin: i.needsAdmin,
+          installed: i.installed === undefined ? false : i.installed,
+          cmd: allowed ? allowed.cmd : '',
+          type: allowed ? (i.id === 'gh-copilot' ? 'manual' : i.id === 'xcode-clt' ? 'gui' : 'npm') : 'manual',
+        };
+      });
       res.writeHead(200, { 'Content-Type': 'application/json', 'Access-Control-Allow-Origin': 'null' });
       res.end(JSON.stringify(payload));
       return;

--- a/src/web/render.ts
+++ b/src/web/render.ts
@@ -29,29 +29,3 @@ export const TIER_CFG: Record<string, {title:string;color:string;bg:string;borde
   red:    { title:'手动处理', color:'#f97316', bg:'rgba(249,115,22,.06)', border:'rgba(249,115,22,.2)', btnLabel:'查看指引' },
   black:  { title:'可选优化', color:'#94a3b8', bg:'rgba(148,163,184,.06)', border:'rgba(148,163,184,.15)', btnLabel:'查看建议' },
 };
-
-export const INSTALLERS = [
-  { id:'claude-code', icon:'🤖', name:'Claude Code', desc:'Anthropic AI 编程工具，Mac 开发首选', cmd:'npm install -g @anthropic-ai/claude-code --registry=https://registry.npmmirror.com' },
-  { id:'gemini-cli', icon:'✨', name:'Gemini CLI', desc:'Google AI CLI，支持 Gemini 2.0 全模态', cmd:'npm install -g @google/gemini-cli --registry=https://registry.npmmirror.com' },
-  { id:'homebrew', icon:'🍺', name:'Homebrew', desc:'macOS 必备包管理器', cmd:"/bin/bash -c \"$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)\"" },
-  { id:'openclaw', icon:'🦀', name:'OpenClaw', desc:'开源 AI 助手，支持飞书/Discord 多平台', cmd:'npm install -g openclaw --registry=https://registry.npmmirror.com' },
-  { id:'xcode-clt', icon:'🔧', name:'Xcode CLT', desc:'Xcode Command Line Tools', cmd:'xcode-select --install' },
-];
-
-export const CODING_PLANS = [
-  { icon:'🧠', name:'智谱 GLM Coding Plan', url:'https://www.bigmodel.cn/glm-coding', desc:'GLM-5.1，¥20起/月，按次数计费' },
-  { icon:'☁️', name:'阿里云百炼 Coding Plan', url:'https://www.aliyun.com/benefit/scene/codingplan', desc:'通义+Kimi+GLM，首月¥7.9' },
-  { icon:'🌋', name:'火山方舟 Coding Plan', url:'https://www.volcengine.com/docs/82379/1925114', desc:'豆包+GLM+DeepSeek+Kimi，¥9.9起/月' },
-  { icon:'🌙', name:'Kimi Coding Plan', url:'https://www.kimi.com/code', desc:'Kimi K2.5 编程模型，会员权益含编程额度' },
-  { icon:'🎯', name:'MiniMax Token Plan', url:'https://platform.minimaxi.com/docs/token-plan/promotion', desc:'M2.5 全模态订阅，编程+生图+语音' },
-  { icon:'🌤️', name:'腾讯云 Coding Plan', url:'https://cloud.tencent.com/act/pro/codingplan', desc:'混元+GLM-5+Kimi，首月¥7.9' },
-  { icon:'🚀', name:'无问芯穹 Infini', url:'https://cloud.infini-ai.com/', desc:'聚合多家顶尖编程模型，¥40起/月' },
-  { icon:'🐉', name:'百度千帆 Coding Plan', url:'https://cloud.baidu.com/product/codingplan.html', desc:'文心+多模型编程，首月¥40' },
-];
-
-export const API_PLANS = [
-  { icon:'🧠', name:'智谱 BigModel', url:'https://open.bigmodel.cn/', desc:'GLM 系列 API' },
-  { icon:'💬', name:'DeepSeek', url:'https://platform.deepseek.com/', desc:'R1/V3 API，夜间半价' },
-  { icon:'🌙', name:'Kimi', url:'https://platform.kimi.com/', desc:'K2 系列 API' },
-  { icon:'🎯', name:'MiniMax', url:'https://platform.minimaxi.com/', desc:'M2.5 全模态 API' },
-];


### PR DESCRIPTION
## 修复内容

**问题：**  返回的 JSON 缺少  和  字段，导致复制命令按钮无法工作（安装按钮点击后传空命令）。

**修复：**
- ：将  map 合并到 API 响应中，所有 8 个工具现在都返回正确的  和 （npm/manual/gui）
- ：移除未使用的  数组（数据源改为 API，不再依赖硬编码）

**验证结果（8/8 全绿）：**


**测试：** 
> mac-aicheck@1.0.0 build
> tsc ✅ |  ✅ | API 验证 ✅