### PR TITLE
feat: Agent Lite 监控功能

### DIFF
--- a/bin/mac-aicheck-agent
+++ b/bin/mac-aicheck-agent
@@ -1,0 +1,12 @@
+#!/bin/bash
+# Find mac-aicheck agent entry point
+AGENT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MAC_AICHECK_DIR="$(dirname "$AGENT_DIR")"
+
+# dist/agent/index.js 是唯一的运行版本
+if [ -f "$MAC_AICHECK_DIR/dist/agent/index.js" ]; then
+  exec node "$MAC_AICHECK_DIR/dist/agent/index.js" "$@"
+else
+  echo "Error: mac-aicheck agent not found. Run: npm run build" >&2
+  exit 1
+fi

--- a/dist/api/aicoevo-client.js
+++ b/dist/api/aicoevo-client.js
@@ -63,18 +63,44 @@ function collectSystemInfo() {
     return { os: 'darwin', version, arch, hostname };
 }
 // ===== HTTP Helper =====
+const DEFAULT_TIMEOUT_MS = 8000;
+const RETRYABLE_STATUS_CODES = new Set([408, 429, 500, 502, 503, 504]);
+/**
+ * Fetch with timeout and exponential-backoff retry.
+ * Retries on network errors and retryable HTTP status codes.
+ */
 async function apiFetch(url, options) {
-    const controller = new AbortController();
-    const timer = setTimeout(() => controller.abort(), 8000);
-    try {
-        const response = await fetch(url, { ...options, signal: controller.signal });
-        if (!response.ok)
-            throw new Error(`API 错误: ${response.status} ${response.statusText}`);
-        return response.json();
+    const timeoutMs = options?.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+    const maxRetries = 3;
+    let lastError = null;
+    for (let attempt = 0; attempt <= maxRetries; attempt++) {
+        const controller = new AbortController();
+        const timer = setTimeout(() => controller.abort(), timeoutMs);
+        try {
+            const response = await fetch(url, { ...options, signal: controller.signal });
+            if (response.ok) {
+                return response.json();
+            }
+            if (!RETRYABLE_STATUS_CODES.has(response.status) || attempt === maxRetries) {
+                throw new Error(`API 错误: ${response.status} ${response.statusText}`);
+            }
+            lastError = new Error(`API 错误: ${response.status} ${response.statusText}`);
+        }
+        catch (err) {
+            lastError = err instanceof Error ? err : new Error(String(err));
+            if (lastError.name === 'AbortError' || attempt === maxRetries) {
+                throw lastError;
+            }
+        }
+        finally {
+            clearTimeout(timer);
+        }
+        // Exponential backoff: 500ms, 1000ms, 2000ms
+        if (attempt < maxRetries) {
+            await new Promise(resolve => setTimeout(resolve, 500 * Math.pow(2, attempt)));
+        }
     }
-    finally {
-        clearTimeout(timer);
-    }
+    throw lastError ?? new Error('API 请求失败');
 }
 // ===== Payload Builder =====
 function createPayload(results, score) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -39,6 +39,7 @@ const index_2 = require("./fixers/index");
 const calculator_1 = require("./scoring/calculator");
 const aicoevo_client_1 = require("./api/aicoevo-client");
 const index_3 = require("./installers/index");
+const local_state_1 = require("./agent/local-state");
 const fs = __importStar(require("fs"));
 const path = __importStar(require("path"));
 const http = __importStar(require("http"));
@@ -50,16 +51,8 @@ const DATA_FILE = path.join(WEB_DIR, 'scan-data.json');
 const VERSION = "1.0.0";
 function gc(s) { return s >= 90 ? '#22c55e' : s >= 70 ? '#3b82f6' : s >= 50 ? '#eab308' : '#ef4444'; }
 // Security: whitelisted installer commands only (NEVER trust frontend with arbitrary cmd)
-const ALLOWED_COMMANDS = {
-    'claude-code': { cmd: 'npm install -g @anthropic-ai/claude-code --registry=https://registry.npmmirror.com' },
-    'openclaw': { cmd: 'npm install -g openclaw --registry=https://registry.npmmirror.com' },
-    'gemini-cli': { cmd: 'npm install -g @google/gemini-cli --registry=https://registry.npmmirror.com' },
-    'opencode': { cmd: 'npm install -g opencode-ai --registry=https://registry.npmjs.org' },
-    'ccswitch': { cmd: 'npm install -g ccswitch --registry=https://registry.npmjs.org' },
-    'cute-claude-hooks': { cmd: 'npm install -g cute-claude-hooks --registry=https://registry.npmmirror.com' },
-    'xcode-clt': { cmd: 'xcode-select --install' },
-    'gh-copilot': { cmd: 'gh copilot' },
-};
+// 单数据源：命令定义统一存储在 installers/index.ts 的 getAllowedCommands()
+const ALLOWED_COMMANDS = (0, index_3.getAllowedCommands)();
 function serveHttp() {
     const server = http.createServer((req, res) => {
         const pathname = new URL(req.url || '/', `http://${req.headers.host || 'localhost'}`).pathname;
@@ -80,7 +73,6 @@ function serveHttp() {
         if (pathname === '/api/installers') {
             const all = (0, index_3.getInstallers)();
             const payload = all.map(i => {
-                const allowed = ALLOWED_COMMANDS[i.id];
                 return {
                     id: i.id,
                     name: i.name,
@@ -88,8 +80,8 @@ function serveHttp() {
                     icon: i.icon,
                     needsAdmin: i.needsAdmin,
                     installed: i.installed === undefined ? false : i.installed,
-                    cmd: allowed ? allowed.cmd : '',
-                    type: allowed ? (i.id === 'gh-copilot' ? 'manual' : i.id === 'xcode-clt' ? 'gui' : 'npm') : 'manual',
+                    cmd: i.cmd || '',
+                    type: i.type || 'manual',
                 };
             });
             res.writeHead(200, { 'Content-Type': 'application/json', 'Access-Control-Allow-Origin': 'null' });
@@ -173,10 +165,63 @@ function serveHttp() {
             });
             return;
         }
-        // Block all unknown /api/ routes (except stash, feedback, version-check)
-        if (pathname.startsWith('/api/') && pathname !== '/api/stash' && pathname !== '/api/feedback' && pathname !== '/api/version-check') {
+        // Block all unknown /api/ routes (except stash, feedback, version-check, agent)
+        if (pathname.startsWith('/api/') &&
+            pathname !== '/api/stash' &&
+            pathname !== '/api/feedback' &&
+            pathname !== '/api/version-check' &&
+            !pathname.startsWith('/api/agent')) {
             res.writeHead(404);
             res.end('Not Found');
+            return;
+        }
+        // Agent Lite: 本地状态
+        if (pathname === '/api/agent/status' && req.method === 'GET') {
+            res.writeHead(200, { 'Content-Type': 'application/json', 'Access-Control-Allow-Origin': 'null' });
+            res.end(JSON.stringify((0, local_state_1.getAgentLocalStatus)()));
+            return;
+        }
+        // Agent Lite: 安装本地 runner + hook
+        if (pathname === '/api/agent/enable' && req.method === 'POST') {
+            let body = '';
+            let size = 0;
+            req.on('data', chunk => {
+                size += chunk.length;
+                if (size > MAX_BODY) {
+                    res.writeHead(413);
+                    res.end('Payload Too Large');
+                    return;
+                }
+                body += chunk;
+            });
+            req.on('end', () => {
+                let payload = {};
+                try {
+                    payload = JSON.parse(body);
+                }
+                catch { /* ignore */ }
+                const result = (0, local_state_1.enableAgentExperience)(payload.target || 'all');
+                res.writeHead(200, { 'Content-Type': 'application/json', 'Access-Control-Allow-Origin': 'null' });
+                res.end(JSON.stringify(result));
+            });
+            return;
+        }
+        // Agent Lite: 暂停上传
+        if (pathname === '/api/agent/pause' && req.method === 'POST') {
+            res.writeHead(200, { 'Content-Type': 'application/json', 'Access-Control-Allow-Origin': 'null' });
+            res.end(JSON.stringify((0, local_state_1.pauseAgentUploads)(true)));
+            return;
+        }
+        // Agent Lite: 恢复上传
+        if (pathname === '/api/agent/resume' && req.method === 'POST') {
+            res.writeHead(200, { 'Content-Type': 'application/json', 'Access-Control-Allow-Origin': 'null' });
+            res.end(JSON.stringify((0, local_state_1.pauseAgentUploads)(false)));
+            return;
+        }
+        // Agent Lite: 手动同步一次
+        if (pathname === '/api/agent/sync' && req.method === 'POST') {
+            res.writeHead(200, { 'Content-Type': 'application/json', 'Access-Control-Allow-Origin': 'null' });
+            res.end(JSON.stringify((0, local_state_1.syncAgentEvents)()));
             return;
         }
         // Version check endpoint
@@ -249,7 +294,9 @@ function serveHttp() {
         }
         // Static files with path traversal protection
         let filePath = path.join(WEB_DIR, pathname === '/' ? 'index.html' : pathname);
-        if (!filePath.startsWith(WEB_DIR)) {
+        // Resolve to absolute path before checking boundary (prevents symlink bypass)
+        filePath = path.resolve(filePath);
+        if (!filePath.startsWith(path.resolve(WEB_DIR))) {
             res.writeHead(403);
             res.end('Forbidden');
             return;
@@ -312,7 +359,15 @@ else if (args.includes('--json')) {
         console.log(JSON.stringify(r, null, 2)); }).catch(console.error);
 }
 else if (args.includes('--help') || args.length === 0) {
-    console.log('MacAICheck - AI Dev Environment Checker\nUsage:\n  mac-aicheck          Run diagnosis\n  mac-aicheck fix      Auto-fix detected issues\n  mac-aicheck fix --dry-run   Show what would be fixed\n  mac-aicheck --serve   Start Web UI\n  mac-aicheck --json    JSON output');
+    console.log('MacAICheck - AI Dev Environment Checker\nUsage:\n  mac-aicheck          Run diagnosis\n  mac-aicheck --serve   Start Web UI\n  mac-aicheck --json    JSON output\n  mac-aicheck agent     Agent Lite commands (install-hook, sync, etc.)');
+}
+else if (args.includes('agent')) {
+    // Agent Lite CLI 子命令
+    const agentArgs = args.slice(args.indexOf('agent') + 1);
+    const { spawn: spawnAsync } = require('child_process');
+    const agentCmd = path.join(__dirname, '../bin/mac-aicheck-agent');
+    const proc = spawnAsync('bash', [agentCmd, ...agentArgs], { stdio: 'inherit' });
+    proc.on('close', (code) => { process.exitCode = code ?? 0; });
 }
 else if (args.includes('fix')) {
     const dryRun = args.includes('--dry-run');
@@ -328,7 +383,6 @@ else if (args.includes('fix')) {
             if (r.fixResult) {
                 const icon = r.fixResult.success ? '[+]' : '[-]';
                 console.log(`${icon} ${r.scannerId}: ${r.fixResult.message}`);
-                // Display verification command if fixer provides one (D-21, PST-04)
                 if (r.fixerId) {
                     const fixer = (0, index_2.getFixerById)(r.fixerId);
                     const verificationCmd = fixer?.getVerificationCommand?.();
@@ -338,7 +392,6 @@ else if (args.includes('fix')) {
                         cmds.forEach(cmd => console.log(`      ${cmd}`));
                     }
                 }
-                // Display nextSteps (now includes guidance from getGuidance) (D-14)
                 if (r.fixResult.nextSteps?.length) {
                     for (const step of r.fixResult.nextSteps) {
                         console.log(`    -> ${step}`);

--- a/dist/scanners/index.js
+++ b/dist/scanners/index.js
@@ -33,8 +33,20 @@ var gpu_monitor_1 = require("./gpu-monitor");
 Object.defineProperty(exports, "checkGpu", { enumerable: true, get: function () { return gpu_monitor_1.checkGpu; } });
 async function scanAll() {
     const scanners = (0, registry_1.getScanners)();
-    const results = await Promise.all(scanners.map(s => s.scan()));
+    const results = await Promise.all(scanners.map(s => scanWithTimeout(s, 30_000)));
     return results;
+}
+async function scanWithTimeout(scanner, ms) {
+    return Promise.race([
+        scanner.scan(),
+        new Promise(resolve => setTimeout(() => resolve({
+            id: scanner.id,
+            name: scanner.name,
+            category: scanner.category,
+            status: 'unknown',
+            message: `扫描超时（${ms / 1000}s），跳过`,
+        }), ms)),
+    ]);
 }
 async function scanCategory(category) {
     const scanners = (0, registry_1.getScannerByCategory)(category);

--- a/docs/superpowers/specs/2026-04-14-agent-lite-design.md
+++ b/docs/superpowers/specs/2026-04-14-agent-lite-design.md
@@ -1,0 +1,318 @@
+# mac-aicheck Agent Lite 实现设计
+
+**日期**: 2026-04-14
+**目标**: 为 mac-aicheck 实现与 WinAICheck 完全对齐的 Agent Lite 监控功能
+
+---
+
+## 1. 背景与目标
+
+WinAICheck 已实现完整的 Agent Lite 监控功能：
+- PowerShell profile hook 拦截 AI agent 调用
+- 本地错误捕获、脱敏、fingerprint 生成
+- 批量上传到 aicoevo.net `/api/v1/agent-events/batch`
+- 服务端返回 AI 修复建议（advice）
+
+mac-aicheck 需要实现相同功能，适配 macOS（zsh/bash）。
+
+---
+
+## 2. 架构概览
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                    mac-aicheck Agent 系统                      │
+├─────────────────────────────────────────────────────────────┤
+│  ~/.zshrc / ~/.bashrc                                        │
+│    alias claude='mac-aicheck-agent run --agent claude-code' │
+├─────────────────────────────────────────────────────────────┤
+│                                                             │
+│  mac-aicheck-agent (独立 Node.js 进程)                       │
+│    ├── 解析 --agent, --original 参数                          │
+│    ├── 验证本地 runner 完整性 (SHA256 hash)                   │
+│    ├── spawn 原始 claude 命令，捕获 stderr                    │
+│    ├── 脱敏 + 生成 fingerprint                                │
+│    ├── 本地存储 events.jsonl + daily/*.json                   │
+│    ├── sync 时批量上传到 /api/v1/agent-events/batch           │
+│    └── 写入 advice 到 ~/.mac-aicheck/advice/                 │
+│                                                             │
+│  ~/.mac-aicheck/agent/                                       │
+│    ├── agent-lite.js        ← 内嵌 agent 源码                  │
+│    ├── mac-aicheck-agent   ← shell wrapper 脚本               │
+│    └── agent-lite.hash.json ← 完整性校验                      │
+│                                                             │
+│  ~/.mac-aicheck/                                            │
+│    ├── config.json        ← clientId, deviceId, shareData    │
+│    ├── hooks.json         ← 已安装 hook 信息                  │
+│    ├── outbox/events.jsonl ← 待上传事件                       │
+│    ├── uploads/ledger.jsonl ← 上传记录                        │
+│    ├── advice/latest.json  ← 最新建议                         │
+│    └── daily/YYYY-MM-DD.json ← 每日问题统计                   │
+└─────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## 3. 目录结构
+
+```
+src/agent/
+├── embedded-agent-lite-source.ts   # 内嵌 JS agent 源码（从 WinAICheck 移植）
+├── local-state.ts                   # 主进程侧状态管理（CLI/Web API）
+├── types.ts                         # Agent 相关类型定义
+
+bin/
+└── mac-aicheck-agent                # shell wrapper 脚本（可执行）
+```
+
+---
+
+## 4. 核心组件
+
+### 4.1 embedded-agent-lite-source.ts
+
+从 WinAICheck 移植，适配 macOS：
+
+**修改点**：
+- `getHome()` 返回 `process.env.HOME`
+- `getBaseDir()` 返回 `~/.mac-aicheck`
+- 替换 Windows 路径为 Unix 路径（`\.aicoevo\` → `/.mac-aicheck/`）
+- `agentCmd` 文件改为 `mac-aicheck-agent`（无扩展名）
+- shell hook 改为 zsh profile（`~/.zshrc`），兼容 bash（`~/.bashrc`）
+- 替换 Windows PowerShell hook 语法为 zsh `function claude` 覆盖
+- 移除 Windows 特定路径（`LOCALAPPDATA`、`%USERPROFILE%`）
+
+**功能**：
+- `storeEvent(event)` — 本地存储事件到 `outbox/events.jsonl`
+- `updateDaily(event)` — 更新 `daily/YYYY-MM-DD.json`
+- `syncEvents()` — 批量上传到 `/api/v1/agent-events/batch`
+- `installHook(target)` — 写入 zshrc/bashrc hook 块
+- `uninstallHook(target)` — 移除 hook 块
+- `createEvent({ agent, message })` — 脱敏 + fingerprint
+- `parseArgs(argv)` — 解析 `--agent`, `--original`, `--` 等参数
+- `main(argv)` — CLI 入口
+
+**脱敏模式**（从 WinAICheck 移植）：
+```typescript
+const SENSITIVE_PATTERNS = [
+  { regex: /sk-|api[_-]?key[_-]?([a-zA-Z0-9_-]{20,})/gi, replacement: '<API_KEY>' },
+  { regex: /C:\\Users\\([^\\/\\s]+)/g, replacement: 'C:\\Users\\<USER>' },
+  { regex: /\b(\d{1,3}\.){3}\d{1,3}\b/g, replacement: '<IP>' },
+  { regex: /[\w.-]+@[\w.-]+\.\w+/g, replacement: '<EMAIL>' },
+  // ... macOS 路径适配
+];
+```
+
+### 4.2 local-state.ts
+
+主进程状态管理，与 WinAICheck 架构对齐：
+
+```typescript
+import { execFileSync } from 'child_process';
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs';
+import { homedir } from 'os';
+import { join } from 'path';
+import { AGENT_LITE_SOURCE, AGENT_LITE_HASH } from './embedded-agent-lite-source';
+
+function getBaseDir(): string {
+  return join(homedir(), '.mac-aicheck');
+}
+
+export function getAgentLocalStatus() { /* ... */ }
+export function enableAgentExperience(target?: string) { /* ... */ }
+export function pauseAgentUploads(paused: boolean) { /* ... */ }
+export function syncAgentEvents() { /* ... */ }
+```
+
+**API 端点**（在 main.ts 中添加）：
+- `GET /api/agent/status` — 返回 `getAgentLocalStatus()`
+- `POST /api/agent/enable` — 调用 `enableAgentExperience(target)`
+- `POST /api/agent/pause` — 暂停上传
+- `POST /api/agent/resume` — 恢复上传
+- `POST /api/agent/sync` — 手动触发一次 sync
+
+### 4.3 bin/mac-aicheck-agent
+
+shell wrapper 脚本（类 Unix 可执行文件）：
+
+```bash
+#!/bin/bash
+DIR="$(cd "$(dirname "$0")" && pwd)"
+exec node "$DIR/agent-lite.js" "$@"
+```
+
+---
+
+## 5. CLI 子命令
+
+通过 `mac-aicheck agent <subcommand>` 调用：
+
+| 子命令 | 功能 |
+|--------|------|
+| `install-hook --target claude-code` | 安装 claude hook 到 zshrc |
+| `install-hook --target all` | 安装所有支持 agent 的 hook |
+| `uninstall-hook --target all` | 移除所有 hook |
+| `capture --agent claude-code --message <text>` | 手动记录一条事件 |
+| `capture --agent claude-code --log <path>` | 从日志文件读取并记录 |
+| `sync` | 立即上传 pending 事件到服务端 |
+| `uploads --local` | 显示本地事件和上传记录 |
+| `uploads --remote` | 从服务端拉取已上传事件 |
+| `summary` | 显示今日问题统计 |
+| `advice --format json\|markdown` | 显示最新建议 |
+| `pause` / `resume` | 暂停/恢复自动上传 |
+| `run --agent claude-code --original <path> -- <args>` | 运行原始 agent 并捕获输出 |
+
+---
+
+## 6. 数据流
+
+### 6.1 错误捕获流程
+
+```
+用户执行 claude <args>
+    ↓
+zsh 拦截，执行 mac-aicheck-agent run --agent claude-code --original <path> -- <args>
+    ↓
+mac-aicheck-agent 加载 ~/.mac-aicheck/agent/agent-lite.js
+    ↓
+spawn 原始 claude，捕获 stdout/stderr
+    ↓
+agent-lite.js: createEvent({ agent: 'claude-code', message: stderr })
+    ↓
+agent-lite.js: storeEvent(event) → outbox/events.jsonl + daily/*.json
+    ↓
+如果 exitCode !== 0 或有 stderr 输出：
+  - 显示 "WinAICheck: 已记录 Agent 问题 evt_xxx"
+    ↓
+返回原始 agent 退出码
+```
+
+### 6.2 Sync 流程
+
+```
+用户运行 mac-aicheck agent sync
+    或 autoSync 定时触发（需登录授权）
+    ↓
+syncEvents():
+  - 读取 outbox/events.jsonl
+  - 过滤 syncStatus !== 'synced' 的事件（最多 50 条）
+  - POST /api/v1/agent-events/batch
+  - 服务端返回 { advice?, ... }
+  - 写入本地 advice/latest.json
+  - 标记事件为 synced
+  - 记录到 ledger.jsonl
+```
+
+---
+
+## 7. 服务端 API（aicoevo.net）
+
+**已有接口**（从 aicoevo-platform 确认）：
+- `POST /api/v1/agent-events/batch` — 批量上传事件（需要登录）
+- `GET /api/v1/agent-events/mine` — 获取用户已上传事件（需要登录）
+- `DELETE /api/v1/agent-events/{event_id}` — 删除单条事件
+
+**认证流程**：
+- WinAICheck 使用 email + verification code 登录
+- mac-aicheck 复用相同 auth flow
+- `mac-aicheck agent auth --email <email>` → 发送验证码
+- `mac-aicheck agent auth --verify <code>` → 完成授权
+
+---
+
+## 8. 安全性
+
+### 8.1 脱敏（从 WinAICheck 移植）
+
+事件消息在本地存储和上传前必须脱敏：
+- API keys / tokens → `<API_KEY>`
+- IP 地址 → `<IP>`
+- 邮箱 → `<EMAIL>`
+- Windows 用户路径 → `<USER>`
+- macOS 用户路径 → `/Users/<USER>`（新增）
+- 各类 secret env vars → `<SECRET_ENV>`
+
+### 8.2 本地数据安全
+
+- `config.json`, `hooks.json`: mode 0600
+- 所有数据存储在用户 home 目录，不上传敏感内容
+
+### 8.3 `--log` 参数路径限制
+
+仅允许读取：
+- `$HOME`
+- `$PWD`（当前工作目录）
+- `/tmp/mac-aicheck`
+
+---
+
+## 9. 配置文件
+
+### ~/.mac-aicheck/config.json
+
+```json
+{
+  "clientId": "client_<uuid>",
+  "deviceId": "device_<uuid>",
+  "shareData": false,
+  "autoSync": false,
+  "paused": false,
+  "email": null,
+  "authToken": null,
+  "confirmedAt": null
+}
+```
+
+### ~/.mac-aicheck/hooks.json
+
+```json
+{
+  "installedAt": "2026-04-14T...",
+  "agents": [
+    { "target": "claude-code", "command": "/path/to/claude", "functionName": "claude" }
+  ],
+  "profiles": ["/Users/xxx/.zshrc"]
+}
+```
+
+---
+
+## 10. 测试策略
+
+参考 WinAICheck 的 `tests/agent-lite.test.ts`，mac-aicheck 需覆盖：
+
+1. **事件创建与脱敏** — 各种敏感信息被正确替换
+2. **路径限制** — `--log` 参数拒绝非白名单路径
+3. **daily 聚合** — 同一 fingerprint 事件计数正确
+4. **outbox 读写** — JSONL 追加、rotation
+5. **local-state** — getAgentLocalStatus 返回正确结构
+6. **CLI 参数解析** — `parseArgs` 处理各种输入格式
+
+---
+
+## 11. 移植检查清单
+
+从 WinAICheck `embedded-agent-lite-source.ts` 移植时需修改：
+
+| 原内容 | 改为 |
+|--------|------|
+| `process.env.USERPROFILE \|\| process.env.HOME` | `process.env.HOME` |
+| `\.aicoevo\` | `/.mac-aicheck/` |
+| `C:\Users\...` | `/Users/<USER>` |
+| `winaicheck-agent.cmd` | `mac-aicheck-agent` |
+| PowerShell profile hook | zsh `function` hook |
+| `%HOME%` 环境变量 | `$HOME` |
+| `join(homedir(), '.aicoevo')` | `join(homedir(), '.mac-aicheck')` |
+
+---
+
+## 12. 实施顺序
+
+1. **创建 `src/agent/embedded-agent-lite-source.ts`** — 移植 agent-lite 源码
+2. **创建 `src/agent/types.ts`** — 类型定义
+3. **创建 `src/agent/local-state.ts`** — 主进程状态管理
+4. **创建 `bin/mac-aicheck-agent`** — shell wrapper
+5. **修改 `src/main.ts`** — 添加 `/api/agent/*` 端点
+6. **添加 `mac-aicheck agent` CLI 子命令** — 入口
+7. **编写测试** — 覆盖核心逻辑
+8. **集成测试** — 完整流程验证

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -1,0 +1,278 @@
+// Agent Lite CLI - 简洁实现
+import { existsSync, mkdirSync, readFileSync, writeFileSync, chmodSync, copyFileSync, appendFileSync } from 'fs';
+import { join } from 'path';
+import { homedir } from 'os';
+import { execFileSync, spawn } from 'child_process';
+import crypto from 'node:crypto';
+
+function getHome() { return process.env.HOME || homedir(); }
+function getBaseDir() { return join(getHome(), '.mac-aicheck'); }
+function paths() {
+  const base = getBaseDir();
+  return {
+    base, config: join(base, 'config.json'), hooks: join(base, 'hooks.json'),
+    outbox: join(base, 'outbox', 'events.jsonl'), ledger: join(base, 'uploads', 'ledger.jsonl'),
+    adviceJson: join(base, 'advice', 'latest.json'), adviceMd: join(base, 'advice', 'latest.md'),
+    dailyDir: join(base, 'daily'), agentDir: join(base, 'agent'),
+    agentJs: join(base, 'agent', 'agent-lite.js'), agentCmd: join(base, 'agent', 'mac-aicheck-agent'),
+  };
+}
+function ensureDir(dir: string) { if (!existsSync(dir)) mkdirSync(dir, { recursive: true }); }
+function readJson<T>(file: string, fallback: T): T { try { return existsSync(file) ? JSON.parse(readFileSync(file, 'utf-8')) : fallback; } catch { return fallback; } }
+function writeJson(file: string, data: unknown, mode = 0o600) { ensureDir(join(file, '..')); writeFileSync(file, JSON.stringify(data, null, 2) + '\n', { encoding: 'utf-8', mode }); }
+function appendJsonl(file: string, data: unknown) { ensureDir(join(file, '..')); appendFileSync(file, JSON.stringify(data) + '\n', 'utf-8'); }
+function readJsonl(file: string): unknown[] { try { if (!existsSync(file)) return []; return readFileSync(file, 'utf-8').split(/\r?\n/).filter(Boolean).map(l => { try { return JSON.parse(l); } catch { return null; } }).filter(Boolean); } catch { return []; } }
+
+function sha256(v: string) { return crypto.createHash('sha256').update(v).digest('hex'); }
+function shortHash(v: string) { return sha256(v).slice(0, 16); }
+function nowIso() { return new Date().toISOString(); }
+function today() { return nowIso().slice(0, 10); }
+
+const SENSITIVE_PATTERNS: Array<{ regex: RegExp; replacement: string }> = [
+  { regex: /(?:sk-|api[_-]?key[_-]?)([a-zA-Z0-9_-]{20,})/gi, replacement: '<API_KEY>' },
+  { regex: /Bearer\s+[a-zA-Z0-9._-]+/gi, replacement: 'Bearer <TOKEN>' },
+  { regex: /\/Users\/([^\/\s]+)/gi, replacement: '/Users/<USER>' },
+  { regex: /\b(\d{1,3}\.){3}\d{1,3}\b/g, replacement: '<IP>' },
+  { regex: /[\w.-]+@[\w.-]+\.\w+/g, replacement: '<EMAIL>' },
+  { regex: /(?:OPENAI|ANTHROPIC|OPENROUTER|OPENCLAW|DASHSCOPE|ZHIPU|MOONSHOT|GEMINI)[\w-]*(?:KEY|TOKEN)?\s*=\s*[^\s]+/gi, replacement: '<SECRET_ENV>' },
+];
+
+function sanitizeText(text: string): string { let r = String(text || ''); for (const p of SENSITIVE_PATTERNS) r = r.replace(p.regex, p.replacement); return r; }
+function trimForCapture(text: string): string { const s = sanitizeText(text); return s.length <= 8000 ? s : s.slice(0, 8000) + '\n<TRUNCATED>'; }
+
+function loadConfig() {
+  const p = paths();
+  const cfg = readJson(p.config, {} as Record<string, unknown>);
+  if (!cfg.clientId) cfg.clientId = `client_${crypto.randomUUID()}`;
+  if (!cfg.deviceId) cfg.deviceId = `device_${crypto.randomUUID()}`;
+  if (cfg.shareData === undefined) cfg.shareData = false;
+  if (cfg.autoSync === undefined) cfg.autoSync = false;
+  if (cfg.paused === undefined) cfg.paused = false;
+  writeJson(p.config, cfg);
+  return cfg as { clientId: string; deviceId: string; shareData: boolean; autoSync: boolean; paused: boolean; email?: string; authToken?: string };
+}
+function saveConfig(cfg: Record<string, unknown>) { writeJson(paths().config, cfg); }
+
+function normalizeAgent(v: string): string { const a = String(v || 'custom').toLowerCase(); return (a === 'claude' || a === 'claude-code' || a === 'claude_code') ? 'claude-code' : a === 'openclaw' || a === 'open-claw' ? 'openclaw' : 'custom'; }
+function classifyEvent(agent: string, msg: string): string { const t = msg.toLowerCase(); if (t.includes('mcp')) return 'mcp_error'; if (t.includes('config') || t.includes('json')) return 'agent_config'; if (t.includes('traceback') || t.includes('syntaxerror') || t.includes('typeerror')) return 'coding_error_summary'; return agent === 'custom' ? 'coding_error_summary' : 'agent_runtime'; }
+function severityFromMsg(msg: string, fallback = 'error'): string { const t = msg.toLowerCase(); return t.includes('warn') ? 'warn' : t.includes('info') ? 'info' : fallback; }
+
+function createEvent(input: { agent?: string; message?: string; eventType?: string; severity?: string; occurredAt?: string; fingerprint?: string; eventId?: string }) {
+  const config = loadConfig();
+  const agent = normalizeAgent(input.agent || '');
+  const sanitizedMessage = trimForCapture(input.message || '');
+  const eventType = input.eventType || classifyEvent(agent, sanitizedMessage);
+  const occurredAt = input.occurredAt || nowIso();
+  return {
+    schemaVersion: 1,
+    eventId: input.eventId || `evt_${crypto.randomUUID()}`,
+    clientId: config.clientId,
+    deviceId: config.deviceId,
+    source: 'mac-aicheck-lite',
+    agent,
+    eventType,
+    occurredAt,
+    fingerprint: input.fingerprint || shortHash(`${agent}\n${eventType}\n${sanitizedMessage.replace(/\d+/g, '<N>')}`),
+    sanitizedMessage,
+    severity: input.severity || severityFromMsg(sanitizedMessage),
+    localContext: { os: `${process.platform} ${process.release.name || process.platform}`, shell: process.env.SHELL || '', node: process.version, cwdHash: shortHash(process.cwd()) },
+    syncStatus: 'pending',
+  };
+}
+
+function storeEvent(event: ReturnType<typeof createEvent>) {
+  const p = paths();
+  appendJsonl(p.outbox, event);
+  const date = event.occurredAt.slice(0, 10);
+  const file = join(p.dailyDir, `${date}.json`);
+  const pack = readJson(file, { date, totalEvents: 0, uniqueFingerprints: 0, repeatedEvents: 0, fixedEvents: 0, topProblems: [] as Array<{ fingerprint: string; title: string; count: number; status: string }> });
+  pack.totalEvents++;
+  const prob = pack.topProblems.find(item => item.fingerprint === event.fingerprint);
+  if (prob) { prob.count++; prob.status = 'repeated'; pack.repeatedEvents++; }
+  else pack.topProblems.push({ fingerprint: event.fingerprint, title: event.sanitizedMessage.split('\n')[0].slice(0, 120) || event.eventType, count: 1, status: 'new' });
+  pack.uniqueFingerprints = pack.topProblems.length;
+  pack.topProblems.sort((a, b) => b.count - a.count);
+  writeJson(file, pack);
+  return event;
+}
+
+function parseArgs(argv: string[]): Record<string, unknown> {
+  const r: Record<string, unknown> = { _: [] };
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === '--') { r._ = argv.slice(i + 1); break; }
+    if (arg.startsWith('--')) {
+      const [k, v] = arg.slice(2).split(/=(.*)/s);
+      const key = k.replace(/-([a-z])/g, (_, c: string) => c.toUpperCase());
+      r[key] = v !== undefined ? v : (argv[i + 1] && !argv[i + 1].startsWith('--') ? argv[++i] : true);
+    } else { (r._ as string[]).push(arg); }
+  }
+  return r;
+}
+
+function apiBase() {
+  const raw = (process.env.AICOEVO_API_BASE || process.env.AICOEVO_BASE_URL || 'https://aicoevo.net').replace(/\/+$/, '');
+  if (!raw.startsWith('https://') && process.env.NODE_ENV !== 'development') return raw.replace(/^http:\/\//, 'https://').endsWith('/api/v1') ? raw.replace(/^http:\/\//, 'https://') : `${raw.replace(/^http:\/\//, 'https://')}/api/v1`;
+  return raw.endsWith('/api/v1') ? raw : `${raw}/api/v1`;
+}
+
+async function requestJson(url: string, init: { method?: string; headers?: Record<string, string>; body?: unknown; timeoutMs?: number } = {}) {
+  const resp = await fetch(url, { method: init.method || 'GET', headers: { Accept: 'application/json', ...(init.body ? { 'Content-Type': 'application/json' } : {}), ...(init.headers || {}) }, body: init.body ? JSON.stringify(init.body) : undefined, signal: AbortSignal.timeout(init.timeoutMs || 5000) });
+  const text = await resp.text();
+  let data = {};
+  try { data = JSON.parse(text); } catch { data = { _raw: text.slice(0, 200) }; }
+  return { status: resp.status, data };
+}
+
+async function syncEvents() {
+  const p = paths();
+  const config = loadConfig();
+  if (config.paused) return { ok: false, skipped: true, reason: 'paused' };
+  if (!config.shareData) return { ok: false, skipped: true, reason: 'not_authorized' };
+  const all = readJsonl(p.outbox) as Array<Record<string, unknown>>;
+  const pending = all.filter(e => e.syncStatus !== 'synced').slice(0, 50);
+  if (!pending.length) return { ok: true, uploaded: 0 };
+  const remote = await requestJson(`${apiBase()}/agent-events/batch`, { method: 'POST', headers: config.authToken ? { Authorization: `Bearer ${config.authToken}` } : {}, body: { clientId: config.clientId, deviceId: config.deviceId, events: pending.map(({ syncStatus, ...e }) => e) } });
+  if (remote.status < 200 || remote.status >= 300) return { ok: false, uploaded: 0, status: remote.status };
+  const pendingIds = new Set(pending.map(e => e.eventId));
+  const updated = all.map(e => pendingIds.has(e.eventId) ? { ...e, syncStatus: 'synced', syncedAt: nowIso() } : e);
+  writeFileSync(p.outbox, updated.map(e => JSON.stringify(e)).join('\n') + '\n', 'utf-8');
+  if ((remote.data as Record<string, unknown>)?.advice) writeAdvice((remote.data as Record<string, unknown>).advice as Record<string, unknown>);
+  return { ok: true, uploaded: pending.length };
+}
+
+function writeAdvice(advice: Record<string, unknown>) {
+  const p = paths();
+  const norm = { schemaVersion: 1, adviceId: advice.adviceId || `adv_${crypto.randomUUID()}`, generatedAt: advice.generatedAt || nowIso(), summary: advice.summary || 'AICOEVO 已生成新的优化建议。', confidence: typeof advice.confidence === 'number' ? advice.confidence : 0, steps: Array.isArray(advice.steps) ? advice.steps : [], links: Array.isArray(advice.links) ? advice.links : [] };
+  writeJson(p.adviceJson, norm);
+  const lines = ['# AICOEVO 修复建议', '', norm.summary, '', `置信度: ${Math.round(norm.confidence * 100)}%`, ''];
+  const SAFE_CMD = /^[a-zA-Z0-9._\-\/\\: ]+$/;
+  if (norm.steps.length) { lines.push('## 建议步骤', ''); norm.steps.forEach((s: Record<string, unknown>, i: number) => { lines.push(`${i+1}. ${s.title}`); if (s.detail) lines.push(`   ${s.detail}`); if (s.command && SAFE_CMD.test(String(s.command))) lines.push(`   命令: \`${s.command}\``); }); lines.push(''); }
+  if (norm.links.length) { lines.push('## 参考链接', ''); norm.links.forEach((l: Record<string, unknown>) => lines.push(`- [${l.title}](${l.url})`)); lines.push(''); }
+  ensureDir(join(p.adviceMd, '..'));
+  writeFileSync(p.adviceMd, lines.join('\n') + '\n', 'utf-8');
+}
+
+function resolveCommand(cmd: string) { try { return execFileSync('command', ['-v', cmd], { encoding: 'utf-8', stdio: ['ignore', 'pipe', 'ignore'] }).split('\n').filter(Boolean)[0] || cmd; } catch { return cmd; } }
+function defaultProfilePaths() { const h = getHome(); return [join(h, '.zshrc'), join(h, '.bashrc'), join(h, '.bash_profile')]; }
+
+function buildHookBlock(agents: Array<{ target: string; command: string; functionName: string; original: string }>) {
+  const HOOK_START = '# >>> mac-aicheck Agent Hook >>>';
+  const HOOK_END = '# <<< mac-aicheck Agent Hook <<<';
+  const lines = [HOOK_START, '# This block is managed by mac-aicheck.'];
+  for (const a of agents) {
+    const orig = a.original.replace(/'/g, "'\"'\"'");
+    lines.push(`function ${a.functionName} {`);
+    lines.push(`  local mac_aicheck_agent="${paths().agentCmd}"`);
+    lines.push(`  if [ -f "$mac_aicheck_agent" ]; then`);
+    lines.push(`    "$mac_aicheck_agent" run --agent ${a.target} --original '${orig}' -- "$@"`);
+    lines.push(`  else`);
+    lines.push(`    command ${a.functionName} "$@"`);
+    lines.push(`  fi`);
+    lines.push(`}`);
+  }
+  lines.push(HOOK_END);
+  return lines.join('\n');
+}
+
+function stripHookBlock(text: string) {
+  const HOOK_START = '# >>> mac-aicheck Agent Hook >>>';
+  const HOOK_END = '# <<< mac-aicheck Agent Hook <<<';
+  let r = text;
+  while (true) { const s = r.indexOf(HOOK_START), e = r.indexOf(HOOK_END); if (s === -1 || e === -1 || e < s) break; r = `${r.slice(0, s).trimEnd()}\n${r.slice(e + HOOK_END.length).trimStart()}`; }
+  return r.trim() + '\n';
+}
+
+function installHook(args: Record<string, unknown>) {
+  const p = paths();
+  const target = String(args.target || 'all');
+  const agents = (target === 'all' ? [{ target: 'claude-code', command: 'claude', functionName: 'claude' }] : target === 'claude-code' || target === 'claude' ? [{ target: 'claude-code', command: 'claude', functionName: 'claude' }] : [{ target: 'openclaw', command: 'openclaw', functionName: 'openclaw' }]).map(a => ({ ...a, original: resolveCommand(a.command) }));
+  const profiles = defaultProfilePaths();
+  const hooks = readJson(p.hooks, { installedAt: null as string | null, profiles: [] as string[], agents: [] as Array<{ target: string; command: string; functionName: string; original: string }> });
+  hooks.installedAt = nowIso(); hooks.agents = agents; hooks.profiles = profiles; writeJson(p.hooks, hooks);
+  const block = buildHookBlock(agents);
+  for (const profile of profiles) {
+    const before = existsSync(profile) ? readFileSync(profile, 'utf-8') : '';
+    ensureDir(join(profile, '..'));
+    if (before && !existsSync(`${profile}.mac-aicheck.bak`)) writeFileSync(`${profile}.mac-aicheck.bak`, before, 'utf-8');
+    writeFileSync(profile, `${stripHookBlock(before).trimEnd()}\n\n${block}\n`, 'utf-8');
+  }
+  return { profiles, agents };
+}
+
+function uninstallHook(args: Record<string, unknown>) {
+  const p = paths();
+  const hooks = readJson(p.hooks, {} as Record<string, unknown>);
+  const profiles = (hooks.profiles as string[]) || defaultProfilePaths();
+  for (const profile of profiles) { if (!existsSync(profile)) continue; writeFileSync(profile, stripHookBlock(readFileSync(profile, 'utf-8')), 'utf-8'); }
+  writeJson(p.hooks, { ...hooks, uninstalledAt: nowIso(), target: args.target || 'all' });
+  return { profiles };
+}
+
+function installLocalAgent() {
+  const p = paths(); ensureDir(p.agentDir);
+  const selfPath = process.argv[1] || __filename;
+  copyFileSync(selfPath, p.agentJs); chmodSync(p.agentJs, 0o755);
+  const hash = sha256(readFileSync(p.agentJs, 'utf-8'));
+  writeJson(join(p.agentDir, 'agent-lite.hash.json'), { sha256: hash, installedAt: nowIso() });
+  const cmd = `#!/bin/bash\nSCRIPT_DIR="$(cd "$(dirname "\${BASH_SOURCE[0]}")" && pwd)"\nexec node "$SCRIPT_DIR/agent-lite.js" "$@"\n`;
+  writeFileSync(p.agentCmd, cmd, 'utf-8'); chmodSync(p.agentCmd, 0o755);
+  return { agentDir: p.agentDir, agentJs: p.agentJs, agentCmd: p.agentCmd };
+}
+
+async function runOriginalAgent(args: Record<string, unknown>) {
+  const original = String(args.original); if (!original) throw new Error('缺少 --original');
+  const passthrough = (args._ as string[]) || []; const stderrChunks: Buffer[] = [];
+  const child = spawn(original, passthrough, { stdio: ['inherit', 'inherit', 'pipe'], shell: process.platform === 'darwin' ? '/bin/zsh' : '/bin/sh' });
+  child.stderr?.on('data', (c: Buffer) => { stderrChunks.push(c); process.stderr.write(c); });
+  const exitCode = await new Promise<number>(resolve => { child.on('error', (e: Error) => { stderrChunks.push(Buffer.from(e.message)); resolve(127); }); child.on('close', c => resolve(c ?? 0)); });
+  const stderrText = Buffer.concat(stderrChunks).toString('utf-8');
+  if (exitCode !== 0 || stderrText.trim()) {
+    const event = storeEvent(createEvent({ agent: String(args.agent), message: stderrText.trim() || `${normalizeAgent(String(args.agent))} exited with code ${exitCode}`, severity: exitCode === 0 ? 'warn' : 'error' }));
+    const config = loadConfig(); if (config.autoSync && config.shareData && !config.paused) { try { await syncEvents(); } catch {} }
+    process.stderr.write(`\nmac-aicheck: 已记录 Agent 问题 ${event.eventId}\n`);
+  }
+  return exitCode;
+}
+
+async function main(argv: string[]) {
+  const [command, ...rest] = [argv[0], ...argv.slice(1)];
+  const args = parseArgs(argv.slice(1));
+  if (!command || command === '--help') {
+    process.stdout.write(`mac-aicheck Agent Lite
+
+用法:
+  mac-aicheck agent install-hook --target claude-code|all
+  mac-aicheck agent uninstall-hook --target all
+  mac-aicheck agent capture --agent <name> --message <text>
+  mac-aicheck agent sync
+  mac-aicheck agent pause|resume
+  mac-aicheck agent advice --format json|markdown
+  mac-aicheck agent install-local-agent
+  mac-aicheck agent run --agent <name> --original <cmd>
+`);
+    return 0;
+  }
+  if (command === 'capture') {
+    const msg = String(args.message || '');
+    if (!msg.trim()) throw new Error('没有可记录的错误内容');
+    const event = storeEvent(createEvent({ agent: String(args.agent), message: msg, severity: args.severity as string }));
+    const cfg = loadConfig(); if (cfg.autoSync && cfg.shareData && !cfg.paused) { try { await syncEvents(); } catch {} }
+    process.stdout.write(JSON.stringify({ ok: true, eventId: event.eventId, fingerprint: event.fingerprint }) + '\n');
+    return 0;
+  }
+  if (command === 'sync') { const result = await syncEvents(); process.stdout.write(JSON.stringify(result) + '\n'); return result.ok || result.skipped ? 0 : 1; }
+  if (command === 'pause' || command === 'resume') { const cfg = loadConfig(); cfg.paused = command === 'pause'; saveConfig(cfg); process.stdout.write(command === 'pause' ? '已暂停自动上传。\n' : '已恢复自动上传。\n'); return 0; }
+  if (command === 'install-hook') { const r = installHook(args); process.stdout.write(`已安装 Hook: ${r.agents.map((a: { target: string }) => a.target).join(', ')}\n`); return 0; }
+  if (command === 'install-local-agent') { const r = installLocalAgent(); process.stdout.write(JSON.stringify({ ok: true, ...r }) + '\n'); return 0; }
+  if (command === 'uninstall-hook') { uninstallHook(args); process.stdout.write('已卸载 mac-aicheck Agent Hook。\n'); return 0; }
+  if (command === 'run') return await runOriginalAgent(args);
+  if (command === 'advice') {
+    const p = paths(); const fmt = String(args.format || 'json'); const f = fmt === 'markdown' ? p.adviceMd : p.adviceJson;
+    const content = existsSync(f) ? readFileSync(f, 'utf-8') : (fmt === 'markdown' ? '# AICOEVO 修复建议\n\n暂无建议。\n' : '{}\n');
+    process.stdout.write(content.endsWith('\n') ? content : content + '\n'); return 0;
+  }
+  throw new Error(`未知 agent 命令: ${command}`);
+}
+
+main(process.argv.slice(2)).then(code => { process.exitCode = typeof code === 'number' ? code : 0; }).catch(e => { console.error(`mac-aicheck Agent 错误: ${e.message}`); process.exitCode = 1; });

--- a/src/agent/local-state.ts
+++ b/src/agent/local-state.ts
@@ -1,0 +1,191 @@
+import { execFileSync } from 'child_process';
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs';
+import { homedir } from 'os';
+import { join } from 'path';
+import { copyFileSync } from 'fs';
+import type { AgentStatus } from './types';
+
+function getBaseDir(): string {
+  return join(homedir(), '.mac-aicheck');
+}
+
+function readJson<T>(file: string, fallback: T): T {
+  try {
+    if (!existsSync(file)) return fallback;
+    return JSON.parse(readFileSync(file, 'utf-8')) as T;
+  } catch {
+    return fallback;
+  }
+}
+
+function readJsonl(file: string): unknown[] {
+  try {
+    if (!existsSync(file)) return [];
+    return readFileSync(file, 'utf-8')
+      .split(/\r?\n/)
+      .filter(Boolean)
+      .map(line => {
+        try { return JSON.parse(line); } catch { return null; }
+      })
+      .filter(Boolean);
+  } catch {
+    return [];
+  }
+}
+
+function getPaths() {
+  const base = getBaseDir();
+  return {
+    base,
+    config: join(base, 'config.json'),
+    hooks: join(base, 'hooks.json'),
+    outbox: join(base, 'outbox', 'events.jsonl'),
+    ledger: join(base, 'uploads', 'ledger.jsonl'),
+    adviceJson: join(base, 'advice', 'latest.json'),
+    adviceMd: join(base, 'advice', 'latest.md'),
+    dailyDir: join(base, 'daily'),
+    agentDir: join(base, 'agent'),
+    agentJs: join(base, 'agent', 'agent-lite.js'),
+    agentCmd: join(base, 'agent', 'mac-aicheck-agent'),
+  };
+}
+
+function today(): string {
+  const now = new Date();
+  const y = now.getFullYear();
+  const m = String(now.getMonth() + 1).padStart(2, '0');
+  const d = String(now.getDate()).padStart(2, '0');
+  return `${y}-${m}-${d}`;
+}
+
+function runAgentCommand(args: string[]): string {
+  const paths = getPaths();
+  if (existsSync(paths.agentCmd)) {
+    return execFileSync(paths.agentCmd, args, {
+      encoding: 'utf-8',
+      timeout: 30000,
+    });
+  }
+
+  const localWrapper = join(process.cwd(), 'bin', 'mac-aicheck-agent');
+  if (existsSync(localWrapper)) {
+    return execFileSync(process.execPath, [localWrapper, ...args], {
+      encoding: 'utf-8',
+      timeout: 30000,
+    });
+  }
+
+  return execFileSync('npx', ['mac-aicheck', 'agent', ...args], {
+    encoding: 'utf-8',
+    timeout: 60000,
+  });
+}
+
+function installEmbeddedLocalAgent() {
+  const p = getPaths();
+  mkdirSync(p.agentDir, { recursive: true });
+  // 从 dist/agent/index.js 复制（已编译，可直接运行）
+  const src = join(__dirname, '../agent/index.js');
+  copyFileSync(src, p.agentJs);
+  const hash = require('crypto').createHash('sha256').update(readFileSync(p.agentJs, 'utf-8')).digest('hex');
+  writeFileSync(
+    join(p.agentDir, 'agent-lite.hash.json'),
+    JSON.stringify({ sha256: hash, source: 'cli', installedAt: new Date().toISOString() }, null, 2) + '\n',
+    'utf-8',
+  );
+  const cmd = [
+    '#!/bin/bash',
+    'SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"',
+    'exec node "$SCRIPT_DIR/agent-lite.js" "$@"',
+    '',
+  ].join('\n');
+  writeFileSync(p.agentCmd, cmd, 'utf-8');
+  return {
+    agentDir: p.agentDir,
+    agentJs: p.agentJs,
+    agentCmd: p.agentCmd,
+  };
+}
+
+export function getAgentLocalStatus(): AgentStatus {
+  const paths = getPaths();
+  const config = readJson<Record<string, unknown>>(paths.config, {});
+  const hooks = readJson<Record<string, unknown>>(paths.hooks, {});
+  const events = readJsonl(paths.outbox);
+  const ledger = readJsonl(paths.ledger);
+  const todayPack = readJson(join(paths.dailyDir, `${today()}.json`), {
+    date: today(),
+    totalEvents: 0,
+    uniqueFingerprints: 0,
+    repeatedEvents: 0,
+    fixedEvents: 0,
+    topProblems: [],
+  });
+  const advice = readJson<Record<string, unknown>>(paths.adviceJson, {});
+
+  return {
+    enabled: existsSync(paths.agentCmd) && Array.isArray(hooks.agents) && (hooks.agents as unknown[]).length > 0,
+    localRunnerInstalled: existsSync(paths.agentCmd),
+    paused: !!config.paused,
+    shareData: !!config.shareData,
+    autoSync: !!config.autoSync,
+    email: (config.email as string) || null,
+    agentCmd: paths.agentCmd,
+    hooks: hooks as unknown as AgentStatus['hooks'],
+    totals: {
+      events: events.length,
+      pending: events.filter((event: unknown) => (event as { syncStatus?: string }).syncStatus !== 'synced').length,
+      synced: events.filter((event: unknown) => (event as { syncStatus?: string }).syncStatus === 'synced').length,
+      uploads: ledger.length,
+    },
+    today: todayPack as AgentStatus['today'],
+    latestEvents: events.slice(-20).reverse() as AgentStatus['latestEvents'],
+    latestUploads: ledger.slice(-20).reverse() as AgentStatus['latestUploads'],
+    advice: advice as AgentStatus['advice'],
+  };
+}
+
+export function enableAgentExperience(target = 'all'): { ok: boolean; localAgent: ReturnType<typeof installEmbeddedLocalAgent>; hook: string; status: AgentStatus } {
+  const localAgent = installEmbeddedLocalAgent();
+  let hookOutput = '';
+  let hookOk = false;
+  try {
+    hookOutput = runAgentCommand(['install-hook', '--target', target]);
+    hookOk = true;
+  } catch {
+    hookOk = false;
+  }
+  return {
+    ok: hookOk,
+    localAgent,
+    hook: hookOutput,
+    status: getAgentLocalStatus(),
+  };
+}
+
+export function pauseAgentUploads(paused: boolean): { ok: boolean; output: string; status: AgentStatus } {
+  const output = runAgentCommand([paused ? 'pause' : 'resume']);
+  return {
+    ok: true,
+    output,
+    status: getAgentLocalStatus(),
+  };
+}
+
+export function syncAgentEvents(): { ok: boolean; output: string; status: AgentStatus } {
+  try {
+    const output = runAgentCommand(['sync']);
+    const parsed = JSON.parse(output);
+    return {
+      ok: parsed.ok !== false && !parsed.error,
+      output,
+      status: getAgentLocalStatus(),
+    };
+  } catch {
+    return {
+      ok: false,
+      output: '',
+      status: getAgentLocalStatus(),
+    };
+  }
+}

--- a/src/agent/types.ts
+++ b/src/agent/types.ts
@@ -1,0 +1,121 @@
+// Agent Lite 类型定义
+
+export interface AgentEvent {
+  schemaVersion: number;
+  eventId: string;
+  clientId: string;
+  deviceId: string;
+  source: 'mac-aicheck-lite';
+  agent: string; // 'claude-code' | 'openclaw' | 'custom'
+  eventType: string;
+  occurredAt: string;
+  fingerprint: string;
+  sanitizedMessage: string;
+  severity: 'error' | 'warn' | 'info';
+  localContext: {
+    os: string;
+    shell: string | undefined;
+    node: string;
+    cwdHash: string;
+  };
+  syncStatus: 'pending' | 'synced';
+  syncedAt?: string;
+}
+
+export interface AgentConfig {
+  clientId: string;
+  deviceId: string;
+  shareData: boolean;
+  autoSync: boolean;
+  paused: boolean;
+  email: string | null;
+  authToken: string | null;
+  confirmedAt: string | null;
+}
+
+export interface AgentHooks {
+  installedAt: string | null;
+  agents: Array<{
+    target: string;
+    command: string;
+    functionName: string;
+  }>;
+  profiles: string[];
+  uninstalledAt?: string;
+  target?: string;
+}
+
+export interface DailyPack {
+  date: string;
+  totalEvents: number;
+  uniqueFingerprints: number;
+  repeatedEvents: number;
+  fixedEvents: number;
+  topProblems: Array<{
+    fingerprint: string;
+    title: string;
+    count: number;
+    status: 'new' | 'repeated' | 'fixed';
+  }>;
+}
+
+export interface LedgerEntry {
+  uploadedAt: string;
+  eventId: string;
+  fingerprint: string;
+  status: 'synced' | 'failed';
+  remoteStatus: number;
+}
+
+export interface AgentStatus {
+  enabled: boolean;
+  localRunnerInstalled: boolean;
+  paused: boolean;
+  shareData: boolean;
+  autoSync: boolean;
+  email: string | null;
+  agentCmd: string;
+  hooks: AgentHooks;
+  totals: {
+    events: number;
+    pending: number;
+    synced: number;
+    uploads: number;
+  };
+  today: DailyPack;
+  latestEvents: AgentEvent[];
+  latestUploads: LedgerEntry[];
+  advice: Record<string, unknown>;
+}
+
+export interface SyncResult {
+  ok: boolean;
+  uploaded?: number;
+  skipped?: boolean;
+  reason?: string;
+  status?: number;
+  data?: unknown;
+  error?: string;
+}
+
+export interface EnableResult {
+  ok: boolean;
+  localAgent: {
+    agentDir: string;
+    agentJs: string;
+    agentCmd: string;
+  };
+  hook: string;
+  status: AgentStatus;
+}
+
+export interface CaptureInput {
+  agent: string;
+  message?: string;
+  log?: string;
+  severity?: 'error' | 'warn' | 'info';
+  eventType?: string;
+  occurredAt?: string;
+  fingerprint?: string;
+  eventId?: string;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import { fixAll, getFixerById } from './fixers/index';
 import { calculateScore } from './scoring/calculator';
 import { createPayload, saveLocal, stashData, buildClaimUrl, submitFeedback } from './api/aicoevo-client';
 import { getInstallers, getAllowedCommands } from './installers/index';
+import { getAgentLocalStatus, enableAgentExperience, pauseAgentUploads, syncAgentEvents } from './agent/local-state';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as http from 'http';
@@ -129,10 +130,61 @@ function serveHttp() {
       return;
     }
 
-    // Block all unknown /api/ routes (except stash, feedback, version-check)
-    if (pathname.startsWith('/api/') && pathname !== '/api/stash' && pathname !== '/api/feedback' && pathname !== '/api/version-check') {
+    // Block all unknown /api/ routes (except stash, feedback, version-check, agent)
+    if (pathname.startsWith('/api/') &&
+        pathname !== '/api/stash' &&
+        pathname !== '/api/feedback' &&
+        pathname !== '/api/version-check' &&
+        !pathname.startsWith('/api/agent')) {
       res.writeHead(404);
       res.end('Not Found');
+      return;
+    }
+
+    // Agent Lite: 本地状态
+    if (pathname === '/api/agent/status' && req.method === 'GET') {
+      res.writeHead(200, { 'Content-Type': 'application/json', 'Access-Control-Allow-Origin': 'null' });
+      res.end(JSON.stringify(getAgentLocalStatus()));
+      return;
+    }
+
+    // Agent Lite: 安装本地 runner + hook
+    if (pathname === '/api/agent/enable' && req.method === 'POST') {
+      let body = '';
+      let size = 0;
+      req.on('data', chunk => {
+        size += chunk.length;
+        if (size > MAX_BODY) { res.writeHead(413); res.end('Payload Too Large'); return; }
+        body += chunk;
+      });
+      req.on('end', () => {
+        let payload: { target?: string } = {};
+        try { payload = JSON.parse(body); } catch { /* ignore */ }
+        const result = enableAgentExperience(payload.target || 'all');
+        res.writeHead(200, { 'Content-Type': 'application/json', 'Access-Control-Allow-Origin': 'null' });
+        res.end(JSON.stringify(result));
+      });
+      return;
+    }
+
+    // Agent Lite: 暂停上传
+    if (pathname === '/api/agent/pause' && req.method === 'POST') {
+      res.writeHead(200, { 'Content-Type': 'application/json', 'Access-Control-Allow-Origin': 'null' });
+      res.end(JSON.stringify(pauseAgentUploads(true)));
+      return;
+    }
+
+    // Agent Lite: 恢复上传
+    if (pathname === '/api/agent/resume' && req.method === 'POST') {
+      res.writeHead(200, { 'Content-Type': 'application/json', 'Access-Control-Allow-Origin': 'null' });
+      res.end(JSON.stringify(pauseAgentUploads(false)));
+      return;
+    }
+
+    // Agent Lite: 手动同步一次
+    if (pathname === '/api/agent/sync' && req.method === 'POST') {
+      res.writeHead(200, { 'Content-Type': 'application/json', 'Access-Control-Allow-Origin': 'null' });
+      res.end(JSON.stringify(syncAgentEvents()));
       return;
     }
 
@@ -263,7 +315,14 @@ if (args.includes('--serve') || args.includes('--web')) {
 } else if (args.includes('--json')) {
   runScan(false).then(r => { if (r) console.log(JSON.stringify(r, null, 2)); }).catch(console.error);
 } else if (args.includes('--help') || args.length === 0) {
-  console.log('MacAICheck - AI Dev Environment Checker\nUsage:\n  mac-aicheck          Run diagnosis\n  mac-aicheck --serve   Start Web UI\n  mac-aicheck --json    JSON output');
+  console.log('MacAICheck - AI Dev Environment Checker\nUsage:\n  mac-aicheck          Run diagnosis\n  mac-aicheck --serve   Start Web UI\n  mac-aicheck --json    JSON output\n  mac-aicheck agent     Agent Lite commands (install-hook, sync, etc.)');
+} else if (args.includes('agent')) {
+  // Agent Lite CLI 子命令
+  const agentArgs = args.slice(args.indexOf('agent') + 1);
+  const { spawn: spawnAsync } = require('child_process');
+  const agentCmd = path.join(__dirname, '../bin/mac-aicheck-agent');
+  const proc = spawnAsync('bash', [agentCmd, ...agentArgs], { stdio: 'inherit' });
+  proc.on('close', (code: number | null) => { process.exitCode = code ?? 0; });
 } else if (args.includes('fix')) {
   const dryRun = args.includes('--dry-run');
   const riskLevel = args.includes('--green') ? 'green' :


### PR DESCRIPTION
## Summary
- 实现 mac-aicheck 的 Agent Lite 监控功能，参考 WinAICheck 设计
- 捕获 Claude Code 错误事件、指纹去重、每日聚合、批量同步到 aicoevo.net、服务端建议下发

## 新增文件
- `src/agent/index.ts` — Agent Lite CLI 主程序
- `src/agent/local-state.ts` — 本地状态管理
- `src/agent/types.ts` — 类型定义
- `bin/mac-aicheck-agent` — CLI wrapper
- `docs/superpowers/specs/2026-04-14-agent-lite-design.md` — 设计文档

## 修改文件
- `src/index.ts` — 添加 /api/agent/* HTTP 端点

## 测试
- ✅ `npm run build` 通过
- ✅ `mac-aicheck agent --help` 正常
- ✅ `mac-aicheck agent capture --agent claude-code --message "test"` 正常
- ✅ `~/.mac-aicheck/agent/` 安装正常