### PR TITLE
feat: 增强 CLI 错误捕获

### DIFF
--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -222,13 +222,42 @@ function installLocalAgent() {
 
 async function runOriginalAgent(args: Record<string, unknown>) {
   const original = String(args.original); if (!original) throw new Error('缺少 --original');
-  const passthrough = (args._ as string[]) || []; const stderrChunks: Buffer[] = [];
-  const child = spawn(original, passthrough, { stdio: ['inherit', 'inherit', 'pipe'], shell: process.platform === 'darwin' ? '/bin/zsh' : '/bin/sh' });
+  const passthrough = (args._ as string[]) || [];
+  const stderrChunks: Buffer[] = [];
+  const stdoutChunks: Buffer[] = [];
+  const child = spawn(original, passthrough, { stdio: ['inherit', 'pipe', 'pipe'], shell: process.platform === 'darwin' ? '/bin/zsh' : '/bin/sh' });
   child.stderr?.on('data', (c: Buffer) => { stderrChunks.push(c); process.stderr.write(c); });
+  child.stdout?.on('data', (c: Buffer) => { stdoutChunks.push(c); process.stdout.write(c); });
   const exitCode = await new Promise<number>(resolve => { child.on('error', (e: Error) => { stderrChunks.push(Buffer.from(e.message)); resolve(127); }); child.on('close', c => resolve(c ?? 0)); });
   const stderrText = Buffer.concat(stderrChunks).toString('utf-8');
-  if (exitCode !== 0 || stderrText.trim()) {
-    const event = storeEvent(createEvent({ agent: String(args.agent), message: stderrText.trim() || `${normalizeAgent(String(args.agent))} exited with code ${exitCode}`, severity: exitCode === 0 ? 'warn' : 'error' }));
+  const stdoutText = Buffer.concat(stdoutChunks).toString('utf-8');
+
+  // 提取 Claude Code 输出中的 Error: 块（命令执行失败的错误）
+  const errorBlocks: string[] = [];
+  const errorBlockRegex = /^Error:.*$/gm;
+  let match;
+  while ((match = errorBlockRegex.exec(stdoutText)) !== null) {
+    const block = match[0];
+    // 收集后续几行作为完整错误上下文
+    const lines = stdoutText.slice(match.index).split('\n');
+    const context = lines.slice(0, 6).join('\n');
+    if (context.trim()) errorBlocks.push(context);
+  }
+  // 也提取 Exit code 相关的错误行
+  const exitCodeRegex = /^Error: Exit code \d+.*$/gm;
+  while ((match = exitCodeRegex.exec(stdoutText)) !== null) {
+    const lines = stdoutText.slice(match.index).split('\n');
+    const context = lines.slice(0, 4).join('\n');
+    if (context.trim() && !errorBlocks.some(b => b.includes(match![0]))) errorBlocks.push(context);
+  }
+
+  // 优先用 stderr，其次用提取的 Error 块
+  const errorMessage = stderrText.trim() || errorBlocks.join('\n---\n');
+  const hasError = exitCode !== 0 || !!errorBlocks.length;
+
+  if (hasError) {
+    const msg = errorMessage || `${normalizeAgent(String(args.agent))} exited with code ${exitCode}`;
+    const event = storeEvent(createEvent({ agent: String(args.agent), message: msg, severity: exitCode === 0 && errorBlocks.length ? 'warn' : 'error' }));
     const config = loadConfig(); if (config.autoSync && config.shareData && !config.paused) { try { await syncEvents(); } catch {} }
     process.stderr.write(`\nmac-aicheck: 已记录 Agent 问题 ${event.eventId}\n`);
   }


### PR DESCRIPTION
## Summary
增强 `mac-aicheck agent run` 的错误捕获能力：

1. **同时监听 stdout 和 stderr** — 之前只捕获 stderr
2. **从 Claude Code stdout 提取 Error: 块** — 解析 `Error: ...` 和 `Error: Exit code N` 格式的错误
3. **支持子进程命令执行错误** — 如 `alembic not found`、`python module import failed`

## 错误类型覆盖
从会话记录中提取的真实错误：
- `command not found: alembic` ✅
- `python No module named alembic` ✅  
- `Error: Exit code 1 ...` ✅
- Claude Code 内部 Error: 块 ✅

## Testing
- ✅ `npm run build` 通过
- ✅ `alembic not found` → 正确捕获
- ✅ Python import error → 正确捕获