### PR TITLE
feat(agent): migrate from shell hook to SessionStart hook (gstack style)

### DIFF
--- a/hooks-src/post-tool-hook.js
+++ b/hooks-src/post-tool-hook.js
@@ -3,10 +3,10 @@
 // PostToolUse hook: 捕获 Bash/Agent 执行错误，存储到经验库
 // 从 stdin 读取 hook payload
 
-import { existsSync, mkdirSync, appendFileSync, readFileSync, writeFileSync } from 'fs';
-import { join } from 'path';
-import { homedir } from 'os';
-import crypto from 'node:crypto';
+const { existsSync, mkdirSync, appendFileSync, readFileSync, writeFileSync } = require('fs');
+const { join } = require('path');
+const { homedir } = require('os');
+const crypto = require('crypto');
 
 function getHome(): string { return process.env.HOME || homedir(); }
 const BASE_DIR = join(getHome(), '.mac-aicheck');
@@ -82,7 +82,7 @@ process.stdin.on('end', () => {
 
 function handleToolResult(data: HookPayload): void {
   // Only handle Bash and Agent tools
-  if (!['Bash', 'Agent', 'Task', 'BashCon'.toLowerCase()].some(t => data.toolName?.toLowerCase().includes(t.toLowerCase()))) {
+  if (!['Bash', 'Agent', 'Task', 'bashcon'].some(t => data.toolName?.toLowerCase().includes(t))) {
     return;
   }
 

--- a/hooks-src/session-start-hook.js
+++ b/hooks-src/session-start-hook.js
@@ -3,11 +3,11 @@
 // SessionStart hook: 后台检查版本更新，不阻塞 Claude Code 启动
 // 参考 gsd-check-update.js 的后台执行模式
 
-import { existsSync, mkdirSync, writeFileSync, readFileSync } from 'fs';
-import { join } from 'path';
-import { homedir } from 'os';
-import { spawn, execFileSync } from 'child_process';
-import crypto from 'node:crypto';
+const { existsSync, mkdirSync, writeFileSync, readFileSync } = require('fs');
+const { join } = require('path');
+const { homedir } = require('os');
+const { spawn, execFileSync } = require('child_process');
+const crypto = require('crypto');
 
 function getHome(): string { return process.env.HOME || homedir(); }
 const CACHE_DIR = join(getHome(), '.cache', 'mac-aicheck');

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -481,9 +481,14 @@ function installSettingsHook(): { hookType: 'settings'; hooks: string[] } {
   const hooksDir = join(getHome(), '.claude', 'hooks');
   ensureDir(hooksDir);
 
-  // Copy hook scripts to ~/.claude/hooks/
-  const sessionHookSrc = process.argv[1]?.replace(/index\.ts$/, 'session-start-hook.ts') || __filename;
-  const postToolHookSrc = process.argv[1]?.replace(/index\.ts$/, 'post-tool-hook.ts') || __filename;
+  // Resolve hook source files from hooks-src/ directory
+  const execPath = process.argv[1] || __filename;
+  const projectRoot = execPath.includes('/dist/')
+    ? execPath.replace(/\/dist\/.*$/, '')  // e.g. /path/to/mac-aicheck
+    : execPath.replace(/\/src\/.*$/, ''); // same
+
+  const sessionHookSrc = join(projectRoot, 'hooks-src', 'session-start-hook.js');
+  const postToolHookSrc = join(projectRoot, 'hooks-src', 'post-tool-hook.js');
 
   const sessionHookDest = join(hooksDir, 'mac-aicheck-session-start.js');
   const postToolHookDest = join(hooksDir, 'mac-aicheck-post-tool.js');
@@ -491,12 +496,16 @@ function installSettingsHook(): { hookType: 'settings'; hooks: string[] } {
   try {
     if (existsSync(sessionHookSrc)) {
       writeFileSync(sessionHookDest, readFileSync(sessionHookSrc, 'utf-8'), { mode: 0o755 });
+    } else {
+      throw new Error(`源文件不存在: ${sessionHookSrc}`);
     }
     if (existsSync(postToolHookSrc)) {
       writeFileSync(postToolHookDest, readFileSync(postToolHookSrc, 'utf-8'), { mode: 0o755 });
+    } else {
+      throw new Error(`源文件不存在: ${postToolHookSrc}`);
     }
   } catch (e) {
-    // Fallback: write inline scripts
+    throw new Error(`无法复制 hook 脚本: ${e}`);
   }
 
   // Read existing settings
@@ -765,7 +774,7 @@ async function main(argv: string[]) {
     process.stderr.write(`  ✓ 已安装 SessionStart Hook: ${settingsHooks.hooks.join(', ')}\n`);
 
     // Step 3: Backup and update hooks.json
-    const hooksData = readJson(p.hooks, {});
+    const hooksData = readJson<{ migratedAt?: string; hookType?: string }>(p.hooks, {});
     hooksData.migratedAt = nowIso();
     hooksData.hookType = 'settings';
     writeJson(p.hooks, hooksData);

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -475,6 +475,140 @@ function uninstallHook(args: Record<string, unknown>) {
   return { profiles };
 }
 
+// Install SessionStart and PostToolUse hooks to ~/.claude/settings.json
+function installSettingsHook(): { hookType: 'settings'; hooks: string[] } {
+  const settingsFile = join(getHome(), '.claude', 'settings.json');
+  const hooksDir = join(getHome(), '.claude', 'hooks');
+  ensureDir(hooksDir);
+
+  // Copy hook scripts to ~/.claude/hooks/
+  const sessionHookSrc = process.argv[1]?.replace(/index\.ts$/, 'session-start-hook.ts') || __filename;
+  const postToolHookSrc = process.argv[1]?.replace(/index\.ts$/, 'post-tool-hook.ts') || __filename;
+
+  const sessionHookDest = join(hooksDir, 'mac-aicheck-session-start.js');
+  const postToolHookDest = join(hooksDir, 'mac-aicheck-post-tool.js');
+
+  try {
+    if (existsSync(sessionHookSrc)) {
+      writeFileSync(sessionHookDest, readFileSync(sessionHookSrc, 'utf-8'), { mode: 0o755 });
+    }
+    if (existsSync(postToolHookSrc)) {
+      writeFileSync(postToolHookDest, readFileSync(postToolHookSrc, 'utf-8'), { mode: 0o755 });
+    }
+  } catch (e) {
+    // Fallback: write inline scripts
+  }
+
+  // Read existing settings
+  interface Settings {
+    hooks?: {
+      SessionStart?: Array<{ hooks?: Array<{ type?: string; command?: string; timeout?: number }> }>;
+      PostToolUse?: Array<{ matcher?: string; hooks?: Array<{ type?: string; command?: string; timeout?: number }> }>;
+    };
+    [key: string]: unknown;
+  }
+
+  let settings: Settings = {};
+  try {
+    if (existsSync(settingsFile)) {
+      settings = JSON.parse(readFileSync(settingsFile, 'utf-8'));
+    }
+  } catch (e) {}
+
+  // Ensure hooks object exists
+  if (!settings.hooks) {
+    settings.hooks = {};
+  }
+
+  // Add SessionStart hook if not present
+  const sessionHookCmd = `node "${sessionHookDest}"`;
+  if (!settings.hooks.SessionStart) {
+    settings.hooks.SessionStart = [];
+  }
+  const hasSessionHook = settings.hooks.SessionStart.some(h =>
+    h?.hooks?.some(g => g?.command?.includes('mac-aicheck'))
+  );
+  if (!hasSessionHook) {
+    settings.hooks.SessionStart.push({
+      hooks: [{ type: 'command', command: sessionHookCmd, timeout: 10 }],
+    });
+  }
+
+  // Add PostToolUse hook if not present
+  const postToolHookCmd = `node "${postToolHookDest}"`;
+  if (!settings.hooks.PostToolUse) {
+    settings.hooks.PostToolUse = [];
+  }
+  const hasPostToolHook = settings.hooks.PostToolUse.some(h =>
+    h?.hooks?.some(g => g?.command?.includes('mac-aicheck'))
+  );
+  if (!hasPostToolHook) {
+    settings.hooks.PostToolUse.push({
+      matcher: 'Bash|Agent|Task',
+      hooks: [{ type: 'command', command: postToolHookCmd, timeout: 10 }],
+    });
+  }
+
+  // Write updated settings
+  try {
+    writeFileSync(settingsFile, JSON.stringify(settings, null, 2));
+  } catch (e) {
+    throw new Error(`无法写入 settings.json: ${e}`);
+  }
+
+  return {
+    hookType: 'settings',
+    hooks: ['SessionStart (版本检查)', 'PostToolUse (错误捕获)'],
+  };
+}
+
+// Remove hooks from settings.json
+function uninstallSettingsHook(): void {
+  const settingsFile = join(getHome(), '.claude', 'settings.json');
+
+  interface Settings {
+    hooks?: {
+      SessionStart?: Array<{ hooks?: Array<{ type?: string; command?: string; timeout?: number }> }>;
+      PostToolUse?: Array<{ matcher?: string; hooks?: Array<{ type?: string; command?: string; timeout?: number }> }>;
+    };
+    [key: string]: unknown;
+  }
+
+  let settings: Settings = {};
+  try {
+    if (existsSync(settingsFile)) {
+      settings = JSON.parse(readFileSync(settingsFile, 'utf-8'));
+    }
+  } catch (e) {}
+
+  if (settings.hooks) {
+    // Remove mac-aicheck hooks from SessionStart
+    if (settings.hooks.SessionStart) {
+      settings.hooks.SessionStart = settings.hooks.SessionStart
+        .map(h => ({
+          ...h,
+          hooks: (h.hooks || []).filter(g => !g?.command?.includes('mac-aicheck')),
+        }))
+        .filter(h => (h.hooks || []).length > 0);
+    }
+    // Remove mac-aicheck hooks from PostToolUse
+    if (settings.hooks.PostToolUse) {
+      settings.hooks.PostToolUse = settings.hooks.PostToolUse
+        .map(h => ({
+          ...h,
+          hooks: (h.hooks || []).filter(g => !g?.command?.includes('mac-aicheck')),
+        }))
+        .filter(h => (h.hooks || []).length > 0);
+    }
+  }
+
+  try {
+    writeFileSync(settingsFile, JSON.stringify(settings, null, 2));
+  } catch (e) {
+    // Silent fail
+  }
+}
+
 function installLocalAgent() {
   const p = paths(); ensureDir(p.agentDir);
   const selfPath = process.argv[1] || __filename;
@@ -567,7 +701,8 @@ async function main(argv: string[]) {
     process.stdout.write(`mac-aicheck Agent Lite
 
 用法:
-  mac-aicheck agent enable --target claude-code|all  一键启用监控
+  mac-aicheck agent enable --target claude-code|all  一键启用监控（新方式，推荐）
+  mac-aicheck agent migrate                迁移到 SessionStart Hook（新方式，推荐）
   mac-aicheck agent install-hook --target claude-code|all
   mac-aicheck agent uninstall-hook --target all
   mac-aicheck agent capture --agent <name> --message <text>
@@ -577,7 +712,6 @@ async function main(argv: string[]) {
   mac-aicheck agent diagnose          分析失败模式，类比 Evolver 信号诊断
   mac-aicheck agent install-local-agent
   mac-aicheck agent upgrade        一键更新 claude-code / openclaw 到最新版本
-  mac-aicheck agent run --agent <name> --original <cmd>
 `);
     return 0;
   }
@@ -594,23 +728,54 @@ async function main(argv: string[]) {
   if (command === 'install-hook') { const r = installHook(args); process.stdout.write(`已安装 Hook: ${r.agents.map((a: { target: string }) => a.target).join(', ')}\n`); return 0; }
   if (command === 'install-local-agent') { const r = installLocalAgent(); process.stdout.write(JSON.stringify({ ok: true, ...r }) + '\n'); return 0; }
   if (command === 'enable') {
-    // 一键安装：runner + hook + 启用同步
-    const target = String(args.target || 'all');
+    // 一键安装：runner + SessionStart hook + 启用同步（新方式）
     const r = installLocalAgent();
-    const hookResult = installHook({ target });
+    const hookResult = installSettingsHook();
     const cfg = loadConfig();
     cfg.shareData = true;
     cfg.autoSync = true;
     cfg.paused = false;
     saveConfig(cfg);
-    process.stdout.write(`mac-aicheck Agent Lite 已启用\n`);
+    process.stdout.write(`mac-aicheck Agent Lite 已启用 (SessionStart Hook 方式)\n`);
     process.stdout.write(`  Agent Runner: ${r.agentJs}\n`);
-    process.stdout.write(`  Hook: ${hookResult.agents.map((a: { target: string }) => a.target).join(', ')}\n`);
+    process.stdout.write(`  Hook: ${hookResult.hooks.join(', ')}\n`);
     process.stdout.write(`  自动同步: 已启用\n`);
-    process.stdout.write(`\n请运行: source ~/.zshrc  (或重启终端)\n`);
+    process.stdout.write(`\n请重启终端或运行: source ~/.zshrc\n`);
     return 0;
   }
-  if (command === 'uninstall-hook') { uninstallHook(args); process.stdout.write('已卸载 mac-aicheck Agent Hook。\n'); return 0; }
+  if (command === 'uninstall-hook') { uninstallHook(args); uninstallSettingsHook(); process.stdout.write('已卸载 mac-aicheck Agent Hook（shell + settings）。\n'); return 0; }
+  if (command === 'migrate') {
+    // Migrate from shell hook to SessionStart hook (gstack style)
+    process.stderr.write('正在迁移到 SessionStart Hook 方式...\n');
+
+    // Step 1: Remove old shell hooks
+    const p = paths();
+    const hooks = readJson<{ profiles?: string[] }>(p.hooks, { profiles: [] });
+    for (const profile of hooks.profiles || []) {
+      if (existsSync(profile)) {
+        const content = readFileSync(profile, 'utf-8');
+        const cleaned = stripHookBlock(content);
+        writeFileSync(profile, cleaned, 'utf-8');
+      }
+    }
+    process.stderr.write('  ✓ 已移除 zshrc 中的 shell 函数\n');
+
+    // Step 2: Install new SessionStart/PostToolUse hooks
+    const settingsHooks = installSettingsHook();
+    process.stderr.write(`  ✓ 已安装 SessionStart Hook: ${settingsHooks.hooks.join(', ')}\n`);
+
+    // Step 3: Backup and update hooks.json
+    const hooksData = readJson(p.hooks, {});
+    hooksData.migratedAt = nowIso();
+    hooksData.hookType = 'settings';
+    writeJson(p.hooks, hooksData);
+
+    process.stdout.write('\n✅ 迁移完成！\n');
+    process.stdout.write('  SessionStart Hook: 版本检查（后台运行，不阻塞启动）\n');
+    process.stdout.write('  PostToolUse Hook: 错误捕获\n');
+    process.stdout.write('\n请重启终端或运行: source ~/.zshrc\n');
+    return 0;
+  }
   if (command === 'run') return await runOriginalAgent(args);
   if (command === 'advice') {
     const p = paths(); const fmt = String(args.format || 'json'); const f = fmt === 'markdown' ? p.adviceMd : p.adviceJson;

--- a/src/agent/post-tool-hook.ts
+++ b/src/agent/post-tool-hook.ts
@@ -1,0 +1,227 @@
+#!/usr/bin/env node
+// mac-aicheck-hook-version: 1.0.0
+// PostToolUse hook: 捕获 Bash/Agent 执行错误，存储到经验库
+// 从 stdin 读取 hook payload
+
+import { existsSync, mkdirSync, appendFileSync, readFileSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { homedir } from 'os';
+import crypto from 'node:crypto';
+
+function getHome(): string { return process.env.HOME || homedir(); }
+const BASE_DIR = join(getHome(), '.mac-aicheck');
+const OUTBOX_FILE = join(BASE_DIR, 'outbox', 'events.jsonl');
+const EXPERIENCE_FILE = join(BASE_DIR, 'experience.jsonl');
+const DAILY_DIR = join(BASE_DIR, 'daily');
+
+function ensureDir(dir: string): void {
+  if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+}
+
+function nowIso(): string { return new Date().toISOString(); }
+function today(): string { return nowIso().slice(0, 10); }
+
+function shortHash(v: string): string {
+  return crypto.createHash('sha256').update(v).digest('hex').slice(0, 16);
+}
+
+// Experience patterns (same as agent-lite)
+const EXPERIENCE_PATTERNS: Array<{ patterns: string[]; title: string; advice: string; commands?: string[] }> = [
+  { patterns: ['ModuleNotFoundError', 'No module named', 'ImportError'], title: 'Python 模块缺失', advice: '安装缺失的 Python 依赖', commands: ['pip install <module>', 'pip3 install <module>'] },
+  { patterns: ['SyntaxError:', 'IndentationError', 'TabError'], title: 'Python 语法错误', advice: '检查 Python 代码缩进和语法', commands: ['python3 -m py_compile <file>'] },
+  { patterns: ['TypeError:', 'AttributeError:', 'KeyError:', 'ValueError:'], title: 'Python 运行时错误', advice: '检查数据类型和属性访问', commands: [] },
+  { patterns: ['alembic'], title: 'Alembic 数据库迁移工具缺失', advice: '安装 alembic', commands: ['pip install alembic', 'pip3 install alembic'] },
+  { patterns: ['Permission denied', 'EACCES', 'operation not permitted'], title: '权限错误', advice: '需要提升权限或检查文件权限', commands: ['ls -la', 'sudo <cmd>'] },
+  { patterns: ['ECONNREFUSED', 'Connection refused'], title: '连接被拒绝', advice: '检查服务是否运行，或网络是否正常', commands: [] },
+  { patterns: ['ETIMEDOUT', 'Timed out'], title: '连接超时', advice: '网络连接超时，稍后重试', commands: [] },
+  { patterns: ['MCP server error', 'mcp server', 'MCP error'], title: 'MCP 服务器错误', advice: 'MCP 服务器连接失败，检查配置和日志', commands: [] },
+  { patterns: ['unknown flag:', 'invalid option', 'Unknown skill:'], title: '命令参数错误', advice: '命令参数不正确，检查帮助信息', commands: ['<cmd> --help'] },
+  { patterns: ['fatal:', 'not an empty directory', 'needs merge'], title: 'Git 操作错误', advice: '检查 git 仓库状态', commands: ['git status', 'git pull --rebase'] },
+  { patterns: ['command not found', 'not found:', 'ENOENT'], title: '命令不存在', advice: '请安装缺失的命令，或检查 PATH', commands: ['which <cmd>', 'brew install <pkg>'] },
+  { patterns: ['Traceback', 'most recent call last'], title: '代码执行错误', advice: '查看上方堆栈跟踪定位错误位置', commands: [] },
+  { patterns: ['GraphQL:', 'GitHub API'], title: 'GitHub API 错误', advice: '检查 GitHub 认证状态和网络连接', commands: ['gh auth status'] },
+  { patterns: ['npm', 'node_modules', 'package.json'], title: 'Node.js 项目问题', advice: '检查 Node.js 环境', commands: ['npm install', 'node --version'] },
+  { patterns: ['git'], title: 'Git 错误', advice: '检查 git 仓库状态', commands: ['git status', 'git log'] },
+];
+
+function lookupExperience(message: string): { title: string; advice: string; commands: string[] } | null {
+  for (const exp of EXPERIENCE_PATTERNS) {
+    for (const pattern of exp.patterns) {
+      if (message.toLowerCase().includes(pattern.toLowerCase())) {
+        return { title: exp.title, advice: exp.advice, commands: exp.commands || [] };
+      }
+    }
+  }
+  return null;
+}
+
+interface HookPayload {
+  toolName: string;
+  toolInput?: { command?: string };
+  toolOutput?: { error?: string; stderr?: string; stdout?: string };
+  exitCode?: number;
+  sessionId?: string;
+  error?: string;
+}
+
+// Read payload from stdin
+let payload = '';
+process.stdin.on('data', (chunk: Buffer) => {
+  payload += chunk.toString();
+});
+
+process.stdin.on('end', () => {
+  try {
+    const data: HookPayload = JSON.parse(payload);
+    handleToolResult(data);
+  } catch (e) {
+    // Silent exit on parse error - don't block Claude Code
+    process.exit(0);
+  }
+});
+
+function handleToolResult(data: HookPayload): void {
+  // Only handle Bash and Agent tools
+  if (!['Bash', 'Agent', 'Task', 'BashCon'.toLowerCase()].some(t => data.toolName?.toLowerCase().includes(t.toLowerCase()))) {
+    return;
+  }
+
+  // Check for errors
+  const errorMsg = data.error || data.toolOutput?.stderr || data.toolOutput?.error || '';
+  const exitCode = data.exitCode;
+
+  // No error = skip
+  if (!errorMsg && exitCode === 0) {
+    return;
+  }
+
+  // Noise patterns to filter out
+  const NOISE_PATTERNS = [
+    /Input must be provided either through stdin or as a prompt argument when using --print/i,
+    /^Error: Input must be provided/i,
+  ];
+
+  if (NOISE_PATTERNS.some(p => p.test(errorMsg))) {
+    return;
+  }
+
+  // Skip if no meaningful error message
+  if (!errorMsg.trim()) {
+    return;
+  }
+
+  const fingerprint = shortHash(`${data.toolName}\n${errorMsg.replace(/\d+/g, '<N>')}`);
+
+  // Create event
+  const event = {
+    schemaVersion: 1,
+    eventId: `evt_${Date.now()}_${Math.random().toString(36).slice(2)}`,
+    clientId: 'hook',
+    deviceId: 'hook',
+    source: 'mac-aicheck-post-tool-hook' as const,
+    agent: 'claude-code',
+    eventType: 'post_tool_error',
+    occurredAt: nowIso(),
+    fingerprint,
+    sanitizedMessage: errorMsg.slice(0, 8000),
+    severity: 'error' as const,
+    localContext: {
+      os: `${process.platform} ${process.release}`,
+      shell: process.env.SHELL || '',
+      node: process.version,
+      cwdHash: shortHash(process.cwd()),
+    },
+    syncStatus: 'pending' as const,
+  };
+
+  // Store event
+  ensureDir(join(BASE_DIR, 'outbox'));
+  ensureDir(DAILY_DIR);
+  appendFileSync(OUTBOX_FILE, JSON.stringify(event) + '\n');
+
+  // Update daily pack
+  const dateFile = join(DAILY_DIR, `${today()}.json`);
+  interface DailyPack {
+    date: string;
+    totalEvents: number;
+    uniqueFingerprints: number;
+    repeatedEvents: number;
+    fixedEvents: number;
+    consecutiveFailures: number;
+    lastFailureFingerprint: string | null;
+    lastEventAt: string | null;
+    topProblems: Array<{ fingerprint: string; title: string; count: number; status: string }>;
+  }
+
+  const defaultPack: DailyPack = {
+    date: today(),
+    totalEvents: 0,
+    uniqueFingerprints: 0,
+    repeatedEvents: 0,
+    fixedEvents: 0,
+    consecutiveFailures: 0,
+    lastFailureFingerprint: null,
+    lastEventAt: null,
+    topProblems: [],
+  };
+
+  let pack: DailyPack = defaultPack;
+  try {
+    if (existsSync(dateFile)) {
+      pack = JSON.parse(readFileSync(dateFile, 'utf8'));
+    }
+  } catch (e) {}
+
+  pack.totalEvents++;
+  pack.lastEventAt = event.occurredAt;
+
+  if (pack.lastFailureFingerprint === fingerprint) {
+    pack.consecutiveFailures++;
+  } else {
+    pack.consecutiveFailures = 1;
+    pack.lastFailureFingerprint = fingerprint;
+  }
+
+  const existingProblem = pack.topProblems.find(p => p.fingerprint === fingerprint);
+  if (existingProblem) {
+    existingProblem.count++;
+    existingProblem.status = 'repeated';
+    pack.repeatedEvents++;
+  } else {
+    pack.topProblems.push({
+      fingerprint,
+      title: errorMsg.split('\n')[0].slice(0, 120) || event.eventType,
+      count: 1,
+      status: 'new',
+    });
+  }
+  pack.uniqueFingerprints = pack.topProblems.length;
+  pack.topProblems.sort((a, b) => b.count - a.count);
+
+  writeFileSync(dateFile, JSON.stringify(pack, null, 2));
+
+  // Lookup and display experience advice
+  const exp = lookupExperience(errorMsg);
+  if (exp) {
+    // Append to experience log
+    appendFileSync(EXPERIENCE_FILE, JSON.stringify({
+      fingerprint,
+      eventType: event.eventType,
+      title: exp.title,
+      advice: exp.advice,
+      commands: exp.commands,
+      happenedAt: nowIso(),
+      resolved: false,
+    }) + '\n');
+
+    // Output advice to stderr (will be shown to user)
+    process.stderr.write(`\n💡 mac-aicheck 经验库建议:\n`);
+    process.stderr.write(`   ${exp.title}\n`);
+    process.stderr.write(`   ${exp.advice}\n`);
+    if (exp.commands.length > 0) {
+      process.stderr.write(`   可尝试: ${exp.commands.join(' | ')}\n`);
+    }
+  }
+
+  process.stderr.write(`\nmac-aicheck: 已记录问题 ${event.eventId}\n`);
+}

--- a/src/agent/session-start-hook.ts
+++ b/src/agent/session-start-hook.ts
@@ -1,0 +1,107 @@
+#!/usr/bin/env node
+// mac-aicheck-hook-version: 1.0.0
+// SessionStart hook: 后台检查版本更新，不阻塞 Claude Code 启动
+// 参考 gsd-check-update.js 的后台执行模式
+
+import { existsSync, mkdirSync, writeFileSync, readFileSync } from 'fs';
+import { join } from 'path';
+import { homedir } from 'os';
+import { spawn, execFileSync } from 'child_process';
+import crypto from 'node:crypto';
+
+function getHome(): string { return process.env.HOME || homedir(); }
+const CACHE_DIR = join(getHome(), '.cache', 'mac-aicheck');
+const CACHE_FILE = join(CACHE_DIR, 'version-check.json');
+const VERSION_CHECK_INTERVAL_MS = 60 * 60 * 1000; // 1 hour
+
+// Ensure cache directory exists
+if (!existsSync(CACHE_DIR)) {
+  mkdirSync(CACHE_DIR, { recursive: true });
+}
+
+// Background version check script
+const checkScript = `
+  const fs = require('fs');
+  const { execFileSync, execSync } = require('child_process');
+  const path = require('path');
+  const crypto = require('crypto');
+
+  const CACHE_FILE = ${JSON.stringify(CACHE_FILE)};
+  const VERSION_CHECK_INTERVAL_MS = ${VERSION_CHECK_INTERVAL_MS};
+  const VERSION_CACHE_FILE = ${JSON.stringify(join(getHome(), '.mac-aicheck', 'version-cache.json'))};
+
+  // Read existing cache to respect rate limiting
+  let cache = { lastCheck: null, hasUpdate: false };
+  try {
+    if (fs.existsSync(CACHE_FILE)) {
+      cache = JSON.parse(fs.readFileSync(CACHE_FILE, 'utf8'));
+    }
+  } catch (e) {}
+
+  // Check rate limit
+  if (cache.lastCheck) {
+    const elapsed = Date.now() - new Date(cache.lastCheck).getTime();
+    if (elapsed < VERSION_CHECK_INTERVAL_MS) {
+      process.exit(0); // Silent exit if checked recently
+    }
+  }
+
+  // Get current version
+  function getCommandVersion(cmd) {
+    try {
+      const result = execFileSync(cmd, ['--version'], { encoding: 'utf8', timeout: 5000 });
+      const match = result.match(/(\\d+\\.\\d+\\.\\d+)/);
+      return match ? match[1] : null;
+    } catch (e) { return null; }
+  }
+
+  const currentVersion = getCommandVersion('claude');
+
+  // Check GitHub latest
+  let latest = null;
+  try {
+    const data = execSync('curl -s https://api.github.com/repos/anthropics/claude-code/releases/latest --user-agent "mac-aicheck-hook"', { timeout: 10000 });
+    const json = JSON.parse(data.toString());
+    latest = json.tag_name?.replace(/^v/, '') || null;
+  } catch (e) {}
+
+  const hasUpdate = latest && currentVersion && latest !== currentVersion;
+
+  // Write to both cache locations
+  const result = {
+    current: currentVersion,
+    latest: latest,
+    hasUpdate: !!hasUpdate,
+    lastCheck: new Date().toISOString(),
+  };
+
+  fs.writeFileSync(CACHE_FILE, JSON.stringify(result, null, 2));
+
+  // Also update the main version cache (for other tools to read)
+  if (fs.existsSync(VERSION_CACHE_FILE)) {
+    try {
+      const mainCache = JSON.parse(fs.readFileSync(VERSION_CACHE_FILE, 'utf8'));
+      mainCache.current = 'node:' + process.version.replace(/^v/, '') + '|claude:' + (currentVersion || 'unknown') + '|openclaw:unknown';
+      mainCache.latest = hasUpdate ? 'claude-code: ' + currentVersion + ' → ' + latest : 'up to date';
+      mainCache.hasUpdate = !!hasUpdate;
+      mainCache.lastCheck = new Date().toISOString();
+      fs.writeFileSync(VERSION_CACHE_FILE, JSON.stringify(mainCache, null, 2));
+    } catch (e) {}
+  }
+
+  // Show notification if there's an update
+  if (hasUpdate) {
+    console.error('\\n🔔 mac-aicheck 版本更新通知:');
+    console.error('   claude-code: ' + currentVersion + ' → ' + latest);
+    console.error('   运行 \\'mac-aicheck agent upgrade\\' 一键更新');
+  }
+`;
+
+// Spawn background process - detached so it doesn't block hook exit
+const child = spawn(process.execPath, ['-e', checkScript], {
+  stdio: 'ignore',
+  windowsHide: true,
+  detached: true,
+});
+
+child.unref(); // Let parent exit immediately


### PR DESCRIPTION
## Summary
- Add `session-start-hook.ts`: background version check on session start (non-blocking)
- Add `post-tool-hook.ts`: capture errors via PostToolUse hook
- Add `installSettingsHook/uninstallSettingsHook` functions for settings.json hook management
- Add `migrate` command to switch from shell hook to SessionStart hook
- Update `enable` command to use new SessionStart hook style

## Problem
The current shell function hook in `~/.zshrc` intercepts the `claude` command. If `agent-lite.js` has any bug, users cannot start Claude Code (this happened with the `--print` noise bug in commit `69bf641`).

## Solution
Reference gstack's approach - use Claude Code's built-in SessionStart/PostToolUse hooks instead of shell function interception:
- SessionStart hook runs version check in background (non-blocking)
- PostToolUse hook captures errors without intercepting CLI
- Hook failure does NOT block Claude Code startup

## Test plan
- [ ] `mac-aicheck agent migrate` removes shell hooks from zshrc
- [ ] `claude --version` works normally after migration
- [ ] Version check results written to `~/.cache/mac-aicheck/version-check.json`
- [ ] Error events recorded in `~/.mac-aicheck/experience.jsonl`