### PR TITLE
fix(agent): use lowercase tool names in PostToolUse hook check

### DIFF
--- a/hooks-src/post-tool-hook.js
+++ b/hooks-src/post-tool-hook.js
@@ -74,7 +74,7 @@ process.stdin.on('end', () => {
 
 function handleToolResult(data) {
   // Only handle Bash and Agent tools
-  if (!['Bash', 'Agent', 'Task', 'bashcon'].some(t => data.toolName?.toLowerCase().includes(t))) {
+  if (!['bash', 'agent', 'task', 'bashcon'].some(t => data.toolName?.toLowerCase().includes(t))) {
     return;
   }
 


### PR DESCRIPTION
## Bug

PostToolUse hook was not recording error events because the tool name check was comparing `toolName.toLowerCase()` (which is `'bash'`) against `['Bash', 'Agent', 'Task', 'bashcon']`. Since only the lowercase `'bashcon'` could ever match, `'Bash'`, `'Agent'`, and `'Task'` errors were being silently skipped.

## Fix

Changed the array from `['Bash', 'Agent', 'Task', 'bashcon']` to `['bash', 'agent', 'task', 'bashcon']` so case-insensitive matching works correctly.

## Test Results

```
=== Test 1: Permission denied ===
💡 mac-aicheck 经验库建议: 权限错误

=== Test 2: ModuleNotFoundError ===
💡 mac-aicheck 经验库建议: Python 模块缺失

=== Test 3: Connection refused (Agent tool) ===
💡 mac-aicheck 经验库建议: 连接被拒绝

=== Test 4: Git error ===
💡 mac-aicheck 经验库建议: Git 操作错误

Total events: 4
Noise filter (--print error): correctly skipped
```