### PR TITLE
fix: send device_id during bind request

### DIFF
--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -872,7 +872,7 @@ async function main(argv: string[]) {
 
     // Step 1: 创建绑定请求
     const reqResult = await requestJson(
-      `${apiBase()}/bind/request?agent_type=${encodeURIComponent(agentName)}&device_info=${encodeURIComponent(deviceInfo)}`,
+      `${apiBase()}/bind/request?agent_type=${encodeURIComponent(agentName)}&device_info=${encodeURIComponent(deviceInfo)}&device_id=${encodeURIComponent(config.deviceId)}`,
       { method: 'POST' },
     );
 


### PR DESCRIPTION
## Summary
- Send `device_id` parameter during `bind` command so aicoevo.net can link bindings to device events

🤖 Generated with [Claude Code](https://claude.com/claude-code)