### PR TITLE
feat: auto-detect and bind agents on enable

### DIFF
--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -779,6 +779,41 @@ async function main(argv: string[]) {
     process.stdout.write(`  Agent Runner: ${r.agentJs}\n`);
     process.stdout.write(`  Hook: ${hookResult.hooks.join(', ')}\n`);
     process.stdout.write(`  自动同步: 已启用\n`);
+
+    // Auto-detect installed agents and bind (#30)
+    if (!cfg.authToken) {
+      const agents: Array<{ name: string; cmd: string }> = [];
+      for (const { name, cmd } of [{ name: 'Claude Code', cmd: 'claude' }, { name: 'OpenClaw', cmd: 'openclaw' }]) {
+        try {
+          execFileSync('command', ['-v', cmd], { encoding: 'utf-8', timeout: 3000, stdio: 'pipe' });
+          agents.push({ name, cmd });
+        } catch { /* not installed */ }
+      }
+      if (agents.length > 0) {
+        process.stdout.write(`\n检测到 ${agents.map(a => a.name).join(', ')}\n`);
+        for (const agent of agents) {
+          try {
+            const deviceInfo = `${hostname()}/${process.platform}`;
+            const reqResult = await requestJson(
+              `${apiBase()}/bind/request?agent_type=${agent.cmd}&device_info=${encodeURIComponent(deviceInfo)}&device_id=${encodeURIComponent(cfg.deviceId)}`,
+              { method: 'POST', timeoutMs: 15000 },
+            );
+            if (reqResult.status === 200) {
+              const { confirm_url } = reqResult.data as Record<string, unknown>;
+              process.stdout.write(`  ${agent.name}: 请在浏览器确认绑定 ${confirm_url}\n`);
+              // Try opening browser
+              try {
+                const openCmd = process.platform === 'darwin' ? 'open' : 'xdg-open';
+                execFileSync(openCmd, [confirm_url as string], { timeout: 5000 });
+              } catch { /* manual */ }
+            }
+          } catch {
+            process.stdout.write(`  ${agent.name}: 绑定请求失败（跳过，可稍后手动绑定）\n`);
+          }
+        }
+      }
+    }
+
     process.stdout.write(`\n请重启终端或运行: source ~/.zshrc\n`);
     return 0;
   }

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -782,11 +782,11 @@ async function main(argv: string[]) {
 
     // Auto-detect installed agents and bind (#30)
     if (!cfg.authToken) {
-      const agents: Array<{ name: string; cmd: string }> = [];
-      for (const { name, cmd } of [{ name: 'Claude Code', cmd: 'claude' }, { name: 'OpenClaw', cmd: 'openclaw' }]) {
+      const agents: Array<{ name: string; cmd: string; agentType: string }> = [];
+      for (const { name, cmd, agentType } of [{ name: 'Claude Code', cmd: 'claude', agentType: 'claude-code' }, { name: 'OpenClaw', cmd: 'openclaw', agentType: 'openclaw' }]) {
         try {
           execFileSync('command', ['-v', cmd], { encoding: 'utf-8', timeout: 3000, stdio: 'pipe' });
-          agents.push({ name, cmd });
+          agents.push({ name, cmd, agentType });
         } catch { /* not installed */ }
       }
       if (agents.length > 0) {
@@ -795,7 +795,7 @@ async function main(argv: string[]) {
           try {
             const deviceInfo = `${hostname()}/${process.platform}`;
             const reqResult = await requestJson(
-              `${apiBase()}/bind/request?agent_type=${agent.cmd}&device_info=${encodeURIComponent(deviceInfo)}&device_id=${encodeURIComponent(cfg.deviceId)}`,
+              `${apiBase()}/bind/request?agent_type=${encodeURIComponent(agent.agentType)}&device_info=${encodeURIComponent(deviceInfo)}&device_id=${encodeURIComponent(cfg.deviceId)}`,
               { method: 'POST', timeoutMs: 15000 },
             );
             if (reqResult.status === 200) {


### PR DESCRIPTION
## Summary

Closes #30 — When running `mac-aicheck agent enable`, automatically:
1. Detect installed agents (Claude Code, OpenClaw) via `command -v`
2. Initiate device binding for each detected agent
3. Open browser for user to confirm binding

## Test plan
- [x] TypeScript compilation passes
- [ ] Run `mac-aicheck agent enable` on a machine with Claude Code installed
- [ ] Verify browser opens with bind confirmation page
- [ ] Verify without any agents installed, no bind requests are made

🤖 Generated with [Claude Code](https://claude.com/claude-code)