### PR TITLE
feat: add 3 P0 fixers — xcode, developer-mode, disk-space

### DIFF
--- a/src/fixers/developer-mode.ts
+++ b/src/fixers/developer-mode.ts
@@ -1,0 +1,111 @@
+import type { Fixer, FixResult, PostFixGuidance } from './types';
+import type { ScanResult } from '../scanners/types';
+import { registerFixer } from './registry';
+import { runCommand } from '../executor/index';
+
+/**
+ * Fixer for macOS Developer Mode (Ventura+).
+ *
+ * On macOS 13+, Developer Mode can be enabled via:
+ * - System Settings → Privacy & Security → Developer Mode (GUI)
+ * - `sudo /usr/sbin/DevToolsSecurity -enable` (partial)
+ *
+ * Full Developer Mode requires a system restart, so this fixer
+ * provides yellow-risk guidance rather than auto-executing.
+ */
+const developerModeFixer: Fixer = {
+  id: 'developer-mode-fixer',
+  name: '开发者模式启用',
+  risk: 'yellow',
+  scannerIds: ['developer-mode'],
+
+  canFix(scanResult: ScanResult): boolean {
+    return scanResult.id === 'developer-mode' && scanResult.status === 'warn';
+  },
+
+  async execute(scanResult: ScanResult, dryRun?: boolean): Promise<FixResult> {
+    if (dryRun) {
+      return {
+        success: true,
+        message: '[dry-run] 将尝试启用 DevToolsSecurity',
+        verified: false,
+      };
+    }
+
+    // Try enabling DevToolsSecurity first (doesn't require full Developer Mode)
+    const result = runCommand('/usr/sbin/DevToolsSecurity -status', 3000);
+    const status = (result.stdout || '').toLowerCase();
+
+    if (status.includes('security policy is not in effect')) {
+      // Need to enable
+      const enableResult = runCommand('sudo /usr/sbin/DevToolsSecurity -enable 2>&1 || echo "NEED_SUDO"', 5000);
+      if ((enableResult.stdout || '').includes('NEED_SUDO')) {
+        return {
+          success: false,
+          message: '需要 sudo 权限启用 DevToolsSecurity',
+          verified: false,
+          nextSteps: [
+            '运行: sudo /usr/sbin/DevToolsSecurity -enable',
+            '或在系统设置中启用开发者模式: 系统设置 → 隐私与安全性 → 开发者模式',
+          ],
+        };
+      }
+    }
+
+    // Check if Developer Mode is available (macOS 13+)
+    const devModeResult = runCommand(
+      'systemsetup -getdevelopermode 2>&1 || echo "UNSUPPORTED"',
+      3000,
+    );
+    const devModeOutput = (devModeResult.stdout || '').toLowerCase();
+
+    if (devModeOutput.includes('unsupported') || devModeResult.exitCode !== 0) {
+      // Older macOS or restricted environment
+      return {
+        success: true,
+        message: 'DevToolsSecurity 已配置。完整开发者模式需要 macOS 13+ 且在恢复模式中启用',
+        verified: false,
+        nextSteps: [
+          '如需完整开发者模式: 重启进入恢复模式 → 安全策略 → 降低安全性 → 允许用户管理内核扩展',
+        ],
+      };
+    }
+
+    if (devModeOutput.includes('developer mode: off')) {
+      return {
+        success: false,
+        message: '开发者模式未启用，需要系统管理员权限且重启后生效',
+        verified: false,
+        nextSteps: [
+          'GUI方式: 系统设置 → 隐私与安全性 → 开发者模式 → 开启',
+          'CLI方式: sudo systemsetup -setdevelopermode on',
+          '启用后需要重启电脑',
+        ],
+      };
+    }
+
+    return {
+      success: true,
+      message: '开发者模式已启用',
+      verified: true,
+    };
+  },
+
+  getGuidance(): PostFixGuidance {
+    return {
+      needsTerminalRestart: false,
+      needsReboot: true,
+      verifyCommands: ['/usr/sbin/DevToolsSecurity -status'],
+      notes: [
+        '完整开发者模式需要重启电脑才能生效',
+        '如无法通过 CLI 启用，请在系统设置中操作',
+      ],
+    };
+  },
+
+  getVerificationCommand(): string {
+    return '/usr/sbin/DevToolsSecurity -status';
+  },
+};
+
+registerFixer(developerModeFixer);

--- a/src/fixers/disk-space.ts
+++ b/src/fixers/disk-space.ts
@@ -1,0 +1,120 @@
+import type { Fixer, FixResult, PostFixGuidance } from './types';
+import type { ScanResult } from '../scanners/types';
+import { registerFixer } from './registry';
+import { runCommand } from '../executor/index';
+
+/**
+ * Fixer for low disk space on temp/system volume.
+ *
+ * Provides guidance for cleaning common macOS caches:
+ * - Homebrew cache
+ * - npm/pip cache
+ * - Xcode DerivedData
+ * - System logs
+ *
+ * This is a yellow-risk fixer: it suggests cleanup commands but
+ * lets the user decide what to delete.
+ */
+const diskSpaceFixer: Fixer = {
+  id: 'disk-space-fixer',
+  name: '磁盘空间清理',
+  risk: 'yellow',
+  scannerIds: ['temp-space'],
+
+  canFix(scanResult: ScanResult): boolean {
+    return scanResult.id === 'temp-space' && scanResult.status === 'fail';
+  },
+
+  async execute(scanResult: ScanResult, dryRun?: boolean): Promise<FixResult> {
+    // Analyze what's using space
+    const tempDir = process.env.TMPDIR || '/tmp';
+    const dfResult = runCommand(`df -Pk "${tempDir}" | tail -n 1`, 5000);
+    const parts = (dfResult.stdout || '').trim().split(/\s+/);
+    const availableKb = parseInt(parts[3] || '0', 10);
+    const freeGb = Math.round(availableKb / 1024 / 1024);
+
+    // Check common cache sizes
+    const cacheInfo: string[] = [];
+    const cleanCommands: string[] = [];
+
+    // Homebrew cache
+    const brewCache = runCommand('du -sh "$(brew --cache 2>/dev/null || echo /dev/null)" 2>/dev/null || true', 5000);
+    if (brewCache.stdout && brewCache.stdout.trim() && !brewCache.stdout.includes('/dev/null')) {
+      const size = brewCache.stdout.split('\t')[0];
+      if (size) {
+        cacheInfo.push(`Homebrew 缓存: ${size}`);
+        cleanCommands.push('brew cleanup --prune=all');
+      }
+    }
+
+    // npm cache
+    const npmCache = runCommand('du -sh "$(npm config get cache 2>/dev/null || echo /dev/null)" 2>/dev/null || true', 5000);
+    if (npmCache.stdout && npmCache.stdout.trim() && !npmCache.stdout.includes('/dev/null')) {
+      const size = npmCache.stdout.split('\t')[0];
+      if (size) {
+        cacheInfo.push(`npm 缓存: ${size}`);
+        cleanCommands.push('npm cache clean --force');
+      }
+    }
+
+    // Xcode DerivedData
+    const derivedData = runCommand('du -sh ~/Library/Developer/Xcode/DerivedData 2>/dev/null || true', 5000);
+    if (derivedData.stdout && derivedData.stdout.trim()) {
+      const size = derivedData.stdout.split('\t')[0];
+      if (size) {
+        cacheInfo.push(`Xcode DerivedData: ${size}`);
+        cleanCommands.push('rm -rf ~/Library/Developer/Xcode/DerivedData/*');
+      }
+    }
+
+    // System logs (last 7 days)
+    const logs = runCommand('du -sh /var/log 2>/dev/null || true', 5000);
+    if (logs.stdout && logs.stdout.trim()) {
+      const size = logs.stdout.split('\t')[0];
+      if (size) {
+        cacheInfo.push(`系统日志: ${size}`);
+      }
+    }
+
+    if (dryRun) {
+      return {
+        success: true,
+        message: `[dry-run] 磁盘剩余 ${freeGb} GB，可清理项:\n${cacheInfo.join('\n')}`,
+        verified: false,
+        nextSteps: cleanCommands,
+      };
+    }
+
+    // For safety, just report findings — user decides what to clean
+    return {
+      success: cacheInfo.length > 0,
+      message: cacheInfo.length > 0
+        ? `磁盘剩余 ${freeGb} GB，发现以下可清理缓存:\n${cacheInfo.join('\n')}`
+        : `磁盘剩余 ${freeGb} GB，未发现明显的可自动清理缓存。请手动检查大文件`,
+      verified: false,
+      nextSteps: [
+        ...cleanCommands.map(cmd => `清理命令: ${cmd}`),
+        '查看大文件: sudo du -sh /* | sort -rh | head -20',
+        '清理下载文件夹: rm -rf ~/Downloads/*.dmg ~/Downloads/*.pkg',
+      ],
+    };
+  },
+
+  getGuidance(): PostFixGuidance {
+    return {
+      needsTerminalRestart: false,
+      needsReboot: false,
+      verifyCommands: ['df -h /'],
+      notes: [
+        '建议定期清理缓存，保持至少 10 GB 可用空间',
+        '可使用 OmniDiskSweeper 或 ncdu 工具可视化磁盘使用',
+      ],
+    };
+  },
+
+  getVerificationCommand(): string {
+    return 'df -h /';
+  },
+};
+
+registerFixer(diskSpaceFixer);

--- a/src/fixers/index.ts
+++ b/src/fixers/index.ts
@@ -10,6 +10,9 @@ import './npm-mirror';
 import './rosetta';
 import './node-version';
 import './python-versions';
+import './xcode';
+import './developer-mode';
+import './disk-space';
 
 // Re-export orchestrator (and its types for backward compatibility)
 export {

--- a/src/fixers/xcode.ts
+++ b/src/fixers/xcode.ts
@@ -1,7 +1,6 @@
 import type { Fixer, FixResult, PostFixGuidance } from './types';
 import type { ScanResult } from '../scanners/types';
 import { registerFixer } from './registry';
-import { classifyError, ERROR_MESSAGES } from './errors';
 import { runCommand } from '../executor/index';
 
 const xcodeFixer: Fixer = {
@@ -48,7 +47,7 @@ const xcodeFixer: Fixer = {
     }
 
     // If GUI install didn't complete (user may have cancelled), try xcode-select --switch
-    const switchResult = runCommand('xcode-select --switch /Library/Developer/CommandLineTools 2>&1 || true', 5000);
+    runCommand('xcode-select --switch /Library/Developer/CommandLineTools 2>&1 || true', 5000);
     const verifyAgain = runCommand('xcode-select -p', 3000);
     if (verifyAgain.exitCode === 0) {
       return {

--- a/src/fixers/xcode.ts
+++ b/src/fixers/xcode.ts
@@ -1,0 +1,87 @@
+import type { Fixer, FixResult, PostFixGuidance } from './types';
+import type { ScanResult } from '../scanners/types';
+import { registerFixer } from './registry';
+import { classifyError, ERROR_MESSAGES } from './errors';
+import { runCommand } from '../executor/index';
+
+const xcodeFixer: Fixer = {
+  id: 'xcode-fixer',
+  name: 'Xcode Command Line Tools 安装',
+  risk: 'green',
+  scannerIds: ['xcode'],
+
+  canFix(scanResult: ScanResult): boolean {
+    return scanResult.id === 'xcode' && scanResult.status === 'fail';
+  },
+
+  async execute(scanResult: ScanResult, dryRun?: boolean): Promise<FixResult> {
+    if (dryRun) {
+      return {
+        success: true,
+        message: '[dry-run] 将执行 xcode-select --install',
+        verified: false,
+      };
+    }
+
+    // Trigger the install dialog (non-blocking, user confirms in GUI)
+    const result = runCommand('xcode-select --install 2>&1 || true', 10_000);
+    const output = (result.stdout || '').toLowerCase();
+
+    // xcode-select --install returns immediately with a dialog
+    // "already installed" means it's actually fine
+    if (output.includes('already installed') || output.includes('command line tools are already')) {
+      return {
+        success: true,
+        message: 'Xcode Command Line Tools 已安装',
+        verified: true,
+      };
+    }
+
+    // Verify installation after dialog
+    const verify = runCommand('xcode-select -p', 3000);
+    if (verify.exitCode === 0) {
+      return {
+        success: true,
+        message: `Xcode Command Line Tools 安装成功: ${verify.stdout.trim()}`,
+        verified: true,
+      };
+    }
+
+    // If GUI install didn't complete (user may have cancelled), try xcode-select --switch
+    const switchResult = runCommand('xcode-select --switch /Library/Developer/CommandLineTools 2>&1 || true', 5000);
+    const verifyAgain = runCommand('xcode-select -p', 3000);
+    if (verifyAgain.exitCode === 0) {
+      return {
+        success: true,
+        message: `Xcode CLT 路径已修正: ${verifyAgain.stdout.trim()}`,
+        verified: true,
+      };
+    }
+
+    return {
+      success: false,
+      message: 'Xcode Command Line Tools 安装未完成。请在弹出的对话框中点击"安装"，或手动运行: xcode-select --install',
+      verified: false,
+      nextSteps: [
+        '手动运行: xcode-select --install',
+        '在弹出的对话框中点击"安装"',
+        '安装完成后重新运行扫描验证',
+      ],
+    };
+  },
+
+  getGuidance(): PostFixGuidance {
+    return {
+      needsTerminalRestart: false,
+      needsReboot: false,
+      verifyCommands: ['xcode-select -p'],
+      notes: ['如果安装对话框未弹出，请尝试: sudo rm -rf /Library/Developer/CommandLineTools && xcode-select --install'],
+    };
+  },
+
+  getVerificationCommand(): string {
+    return 'xcode-select -p';
+  },
+};
+
+registerFixer(xcodeFixer);


### PR DESCRIPTION
## Summary
- 新增 3 个 P0 fixer，推进 Issue #2 三层修复系统
- xcode-fixer (green risk): 自动安装 Xcode Command Line Tools
- developer-mode-fixer (yellow risk): 启用 DevToolsSecurity + 开发者模式指引
- disk-space-fixer (yellow risk): 检测缓存占用并建议清理（brew/npm/xcode）

## Test plan
- [ ] `npx tsc --noEmit` 零错误
- [ ] `fixAll({ dryRun: true })` 正确匹配 xcode/developer-mode/temp-space scanner
- [ ] xcode-fixer: `canFix` 匹配 `id === 'xcode' && status === 'fail'`
- [ ] developer-mode-fixer: `canFix` 匹配 `id === 'developer-mode' && status === 'warn'`
- [ ] disk-space-fixer: `canFix` 匹配 `id === 'temp-space' && status === 'fail'`

Closes #2 (partial — P0 fixers complete)

🤖 Generated with [Claude Code](https://claude.com/claude-code)