### PR TITLE
fix: align ScanResult fields with backend (detail, version, path, fixCommand, severity)

### DIFF
--- a/src/api/aicoevo-client.ts
+++ b/src/api/aicoevo-client.ts
@@ -69,8 +69,12 @@ export interface AICOEVOPayload {
     category: string;
     status: string;
     message: string;
-    details?: string;
+    detail?: string;
     suggestions?: string[];
+    version?: string | null;
+    path?: string | null;
+    fixCommand?: string | null;
+    severity?: string | null;
   }>;
   systemInfo: SystemInfo;
 }
@@ -157,8 +161,12 @@ export function createPayload(results: ScanResult[], score: ScoreResult): AICOEV
       category: r.category,
       status: r.status,
       message: sanitize(r.message),
-      details: r.details ? sanitize(r.details) : undefined,
+      detail: r.detail ? sanitize(r.detail) : undefined,
       suggestions: (r.suggestions || []).map(s => sanitize(s)),
+      version: r.version ?? null,
+      path: r.path ?? null,
+      fixCommand: r.fixCommand ?? null,
+      severity: r.severity ?? null,
     })),
     systemInfo: collectSystemInfo(),
   };

--- a/src/scanners/ccswitch.ts
+++ b/src/scanners/ccswitch.ts
@@ -31,7 +31,7 @@ const scanner: Scanner = {
         id: this.id, name: this.name, category: this.category,
         status: 'pass',
         message: 'CCSwitch 图形版或配置目录已存在',
-        details: appCandidates.filter(existsSync).join('\n'),
+        detail: appCandidates.filter(existsSync).join('\n'),
       };
     }
 
@@ -39,7 +39,7 @@ const scanner: Scanner = {
       id: this.id, name: this.name, category: this.category,
       status: 'warn',
       error_type: 'missing',
-      details: 'macOS 可优先使用 npm install -g ccswitch；若使用图形版，通常位于 /Applications 或 ~/Applications。',
+      detail: 'macOS 可优先使用 npm install -g ccswitch；若使用图形版，通常位于 /Applications 或 ~/Applications。',
       suggestions: ['npm install -g ccswitch'],
     };
   },

--- a/src/scanners/claude-cli.ts
+++ b/src/scanners/claude-cli.ts
@@ -13,7 +13,7 @@ const scanner: Scanner = {
         id: this.id, name: this.name, category: this.category,
         status: 'warn',
         error_type: 'missing',
-        details: 'Claude Code 是 Anthropic 官方命令行 AI 编程助手。',
+        detail: 'Claude Code 是 Anthropic 官方命令行 AI 编程助手。',
         suggestions: ['npm install -g @anthropic-ai/claude-code'],
       };
     }

--- a/src/scanners/claude-config-health.ts
+++ b/src/scanners/claude-config-health.ts
@@ -18,7 +18,7 @@ const scanner: Scanner = {
         status: installed ? 'warn' : 'unknown',
         error_type: installed ? 'misconfigured' : undefined,
         message: installed ? 'Claude Code 已安装，但未发现本地配置文件' : '未检测到 Claude Code 配置',
-        details: '检查项目 .claude/、~/.claude/ 与 ~/.claude.json。',
+        detail: '检查项目 .claude/、~/.claude/ 与 ~/.claude.json。',
       };
     }
 
@@ -27,7 +27,7 @@ const scanner: Scanner = {
         id: this.id, name: this.name, category: this.category,
         status: 'fail',
         error_type: 'misconfigured',
-        details: `文件: ${config.path}\n错误: ${config.error}`,
+        detail: `文件: ${config.path}\n错误: ${config.error}`,
       };
     }
 
@@ -35,7 +35,7 @@ const scanner: Scanner = {
       id: this.id, name: this.name, category: this.category,
       status: 'pass',
       message: 'Claude Code 配置文件可解析',
-      details: `文件: ${config.path}`,
+      detail: `文件: ${config.path}`,
     };
   },
 };

--- a/src/scanners/cpp-compiler.ts
+++ b/src/scanners/cpp-compiler.ts
@@ -20,7 +20,7 @@ const scanner: Scanner = {
       id: this.id, name: this.name, category: this.category,
       status: 'fail',
       error_type: 'missing',
-      details: 'macOS 上建议安装 Xcode Command Line Tools。',
+      detail: 'macOS 上建议安装 Xcode Command Line Tools。',
       suggestions: ['xcode-select --install'],
     };
   },

--- a/src/scanners/cuda-version.ts
+++ b/src/scanners/cuda-version.ts
@@ -21,7 +21,7 @@ const scanner: Scanner = {
         status: metal || mpsAvailable ? 'pass' : 'warn',
         error_type: 'incompatible',
         message: metal || mpsAvailable ? 'Apple GPU / Metal 环境可用' : 'Apple Silicon 已检测到，但未确认 Metal CLI 或 PyTorch MPS',
-        details: `CPU: ${cpu || arch}\nMPS: ${mpsAvailable ? 'PyTorch MPS 可用' : '未确认'}\n${profiler}`,
+        detail: `CPU: ${cpu || arch}\nMPS: ${mpsAvailable ? 'PyTorch MPS 可用' : '未确认'}\n${profiler}`,
         suggestions: metal ? undefined : ['xcode-select --install'],
       };
     }
@@ -30,7 +30,7 @@ const scanner: Scanner = {
       id: this.id, name: this.name, category: this.category,
       status: 'unknown',
       message: '未检测到 Apple Silicon 统一 GPU',
-      details: profiler || 'Intel Mac 可使用 CPU、外接 GPU 或远程 GPU；CUDA 不属于 macOS 原生 AI 加速路径。',
+      detail: profiler || 'Intel Mac 可使用 CPU、外接 GPU 或远程 GPU；CUDA 不属于 macOS 原生 AI 加速路径。',
     };
   },
 };

--- a/src/scanners/env-path-length.ts
+++ b/src/scanners/env-path-length.ts
@@ -19,7 +19,7 @@ const scanner: Scanner = {
         id: this.id, name: this.name, category: this.category,
         status: 'warn',
         error_type: 'misconfigured',
-        details: duplicates.length ? `重复项:\n${duplicates.map(([p, c]) => `  ${p} (x${c})`).join('\n')}` : `建议低于 ${warnLength} 字符。`,
+        detail: duplicates.length ? `重复项:\n${duplicates.map(([p, c]) => `  ${p} (x${c})`).join('\n')}` : `建议低于 ${warnLength} 字符。`,
       };
     }
 

--- a/src/scanners/firewall-ports.ts
+++ b/src/scanners/firewall-ports.ts
@@ -18,7 +18,7 @@ const scanner: Scanner = {
       status: enabled ? 'pass' : 'warn',
       error_type: enabled ? undefined : 'permission',
       message: enabled ? 'macOS 应用防火墙已开启' : 'macOS 应用防火墙未开启或无法确认',
-      details: `Application Firewall: ${firewall.stdout || '(无法读取)'}\npf: ${pf.stdout || '(无法读取)'}\n监听中的 AI 常用端口:\n${listening || '(未发现)'}`,
+      detail: `Application Firewall: ${firewall.stdout || '(无法读取)'}\npf: ${pf.stdout || '(无法读取)'}\n监听中的 AI 常用端口:\n${listening || '(未发现)'}`,
     };
   },
 };

--- a/src/scanners/git-credential-health.ts
+++ b/src/scanners/git-credential-health.ts
@@ -21,7 +21,7 @@ const scanner: Scanner = {
         id: this.id, name: this.name, category: this.category,
         status: 'warn',
         error_type: 'misconfigured',
-        details: 'macOS 推荐使用 credential.helper=osxkeychain，或在 ~/.ssh 中配置 SSH Key。',
+        detail: 'macOS 推荐使用 credential.helper=osxkeychain，或在 ~/.ssh 中配置 SSH Key。',
         suggestions: ['git config --global credential.helper osxkeychain', 'ssh-keygen -t ed25519 -C "you@example.com"'],
       };
     }
@@ -30,7 +30,7 @@ const scanner: Scanner = {
       id: this.id, name: this.name, category: this.category,
       status: hasKeychain || keys.length > 0 ? 'pass' : 'warn',
       message: hasKeychain || keys.length > 0 ? 'Git 凭据链路存在' : 'Git credential helper 已配置，但不是 macOS Keychain',
-      details: `credential.helper: ${helper || '(未配置)'}\nSSH Keys: ${keys.length ? keys.join(', ') : '(未检测到)'}`,
+      detail: `credential.helper: ${helper || '(未配置)'}\nSSH Keys: ${keys.length ? keys.join(', ') : '(未检测到)'}`,
     };
   },
 };

--- a/src/scanners/git-path.ts
+++ b/src/scanners/git-path.ts
@@ -19,7 +19,7 @@ const scanner: Scanner = {
         id: this.id, name: this.name, category: this.category,
         status: 'fail',
         error_type: 'missing',
-        details: `git: ${gitPath}`,
+        detail: `git: ${gitPath}`,
       };
     }
 
@@ -27,7 +27,7 @@ const scanner: Scanner = {
       id: this.id, name: this.name, category: this.category,
       status: 'pass',
       message: 'Git 与常用 Unix 配套命令可用',
-      details: `git: ${gitPath}`,
+      detail: `git: ${gitPath}`,
     };
   },
 };

--- a/src/scanners/git.ts
+++ b/src/scanners/git.ts
@@ -12,18 +12,27 @@ const scanner: Scanner = {
     if (exitCode !== 0) {
       return { id: this.id, name: this.name, category: this.category, status: 'fail',
         error_type: 'missing',
+        fixCommand: 'xcode-select --install',
+        severity: 'high',
         message: 'Git 未安装' };
     }
     const match = stdout.match(/git version (\d+\.\d+\.\d+)/);
-    const version = match?.[1] || 'unknown';
-    const [major, minor] = version.split('.').map(Number);
-    if (major < 2 || (major === 2 && minor < 30)) {
-      return { id: this.id, name: this.name, category: this.category, status: 'warn',
-        error_type: 'outdated',
-        message: `Git ${version} 过旧，建议升级到 2.30+` };
+    const version = match?.[1] || null;
+    const gitPath = runCommand('which git', 3000).stdout.trim() || null;
+    if (version) {
+      const [major, minor] = version.split('.').map(Number);
+      if (major < 2 || (major === 2 && minor < 30)) {
+        return { id: this.id, name: this.name, category: this.category, status: 'warn',
+          error_type: 'outdated',
+          version, path: gitPath,
+          fixCommand: 'brew upgrade git',
+          severity: 'medium',
+          message: `Git ${version} 过旧，建议升级到 2.30+` };
+      }
     }
     return { id: this.id, name: this.name, category: this.category, status: 'pass',
-      message: `Git ${version}` };
+      version, path: gitPath,
+      message: `Git ${version || 'unknown'}` };
   },
 };
 registerScanner(scanner);

--- a/src/scanners/gpu-driver.ts
+++ b/src/scanners/gpu-driver.ts
@@ -23,7 +23,7 @@ const scanner: Scanner = {
       status: hasMetalSupport ? 'pass' : 'warn',
       error_type: hasMetalSupport ? undefined : 'incompatible',
       message: hasMetalSupport ? `Metal 支持正常: ${chipsets.join(', ')}` : `未确认 Metal 支持: ${chipsets.join(', ')}`,
-      details: [`GPU: ${chipsets.join(', ')}`, `metal CLI: ${hasMetalCli ? '可用' : '未检测到'}`, ...metalLines].join('\n'),
+      detail: [`GPU: ${chipsets.join(', ')}`, `metal CLI: ${hasMetalCli ? '可用' : '未检测到'}`, ...metalLines].join('\n'),
       suggestions: hasMetalCli ? undefined : ['xcode-select --install'],
     };
   },

--- a/src/scanners/gpu-monitor.ts
+++ b/src/scanners/gpu-monitor.ts
@@ -93,7 +93,7 @@ function isDiscreteGpu(device: GpuDevice): boolean {
 }
 
 export async function checkGpu(): Promise<ScannerResult> {
-  const details: string[] = [];
+  const detail: string[] = [];
   const suggestions = [GPU_SUMMARY_COMMAND];
 
   const sysctlCpu = runCommand(SYSCTL_CPU_COMMAND, 3000).stdout;
@@ -113,32 +113,32 @@ export async function checkGpu(): Promise<ScannerResult> {
   );
 
   if (cpuBrand) {
-    details.push(`CPU: ${cpuBrand}`);
+    detail.push(`CPU: ${cpuBrand}`);
   }
 
   if (hasUnifiedAppleGpu) {
-    details.push(`统一 GPU: ${(appleGpu?.chipset || cpuBrand || 'Apple Silicon').trim()}`);
+    detail.push(`统一 GPU: ${(appleGpu?.chipset || cpuBrand || 'Apple Silicon').trim()}`);
   }
 
   if (gpuDevices.length > 0) {
-    details.push(
+    detail.push(
       `GPU 列表: ${gpuDevices.map(device => `${device.chipset}${device.vram ? ` (${device.vram})` : ''}`).join(', ')}`
     );
   }
 
   if (externalDisplays.length > 0) {
-    details.push(`外接显示器: ${externalDisplays.join(', ')}`);
+    detail.push(`外接显示器: ${externalDisplays.join(', ')}`);
   }
 
   if (discreteGpus.length > 0) {
-    details.push(`独立 GPU: ${discreteGpus.map(device => device.chipset).join(', ')}`);
+    detail.push(`独立 GPU: ${discreteGpus.map(device => device.chipset).join(', ')}`);
   }
 
   if (profilerSummary) {
-    details.push(`推荐命令输出:\n${profilerSummary}`);
+    detail.push(`推荐命令输出:\n${profilerSummary}`);
   }
 
-  details.push(`Metal 命令行工具: ${hasMetalCli ? '已检测到 metal' : '未检测到 metal'}`);
+  detail.push(`Metal 命令行工具: ${hasMetalCli ? '已检测到 metal' : '未检测到 metal'}`);
 
   if (!hasMetalCli) {
     suggestions.push('xcode-select --install');
@@ -151,7 +151,7 @@ export async function checkGpu(): Promise<ScannerResult> {
       category: 'system',
       status: 'fail',
       message: '未能读取 GPU 信息',
-      details: details.join('\n'),
+      detail: detail.join('\n'),
       suggestions,
       error_type: 'incompatible',
     };
@@ -177,7 +177,7 @@ export async function checkGpu(): Promise<ScannerResult> {
       category: 'system',
       status: 'pass',
       message: summaryParts.join('；') || 'GPU 信息已检测',
-      details: details.join('\n'),
+      detail: detail.join('\n'),
       suggestions,
     };
   }
@@ -188,7 +188,7 @@ export async function checkGpu(): Promise<ScannerResult> {
     category: 'system',
     status: 'warn',
     message: summaryParts.join('；') || 'GPU 信息已检测',
-    details: details.join('\n'),
+    detail: detail.join('\n'),
     suggestions,
     error_type: 'missing',
   };

--- a/src/scanners/homebrew.ts
+++ b/src/scanners/homebrew.ts
@@ -12,12 +12,15 @@ const scanner: Scanner = {
     if (exitCode !== 0) {
       return { id: this.id, name: this.name, category: this.category, status: 'fail',
         error_type: 'missing',
+        fixCommand: '/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"',
+        severity: 'high',
         message: 'Homebrew 未安装，请运行: /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"' };
     }
     const match = stdout.match(/Homebrew (\d+\.\d+\.\d+)/);
-    const version = match?.[1] || 'unknown';
+    const version = match?.[1] || null;
     return { id: this.id, name: this.name, category: this.category, status: 'pass',
-      message: `Homebrew ${version} 已安装` };
+      version,
+      message: `Homebrew ${version || 'unknown'} 已安装` };
   },
 };
 registerScanner(scanner);

--- a/src/scanners/long-paths.ts
+++ b/src/scanners/long-paths.ts
@@ -30,7 +30,7 @@ const scanner: Scanner = {
     const warnLimit = 240;
     const found = scanLongPaths(process.cwd(), warnLimit);
     if (found.length > 0) {
-      return { id: this.id, name: this.name, category: this.category, status: 'warn', error_type: 'misconfigured', message: `发现 ${found.length} 个较长路径`, details: found.join('\n') };
+      return { id: this.id, name: this.name, category: this.category, status: 'warn', error_type: 'misconfigured', message: `发现 ${found.length} 个较长路径`, detail: found.join('\n') };
     }
     return { id: this.id, name: this.name, category: this.category, status: 'pass', message: `当前项目未发现超过 ${warnLimit} 字符的路径` };
   },

--- a/src/scanners/mcp-command-availability.ts
+++ b/src/scanners/mcp-command-availability.ts
@@ -23,14 +23,14 @@ const scanner: Scanner = {
     const commands = collectCommands(config.data);
     const missing = commands.filter(command => !canResolveCommand(command));
     if (commands.length === 0) {
-      return { id: this.id, name: this.name, category: this.category, status: 'unknown', message: 'MCP 配置中未发现 command 字段', details: `文件: ${config.path}` };
+      return { id: this.id, name: this.name, category: this.category, status: 'unknown', message: 'MCP 配置中未发现 command 字段', detail: `文件: ${config.path}` };
     }
     return {
       id: this.id, name: this.name, category: this.category,
       status: missing.length ? 'warn' : 'pass',
       error_type: missing.length ? 'missing' : undefined,
       message: missing.length ? `部分 MCP command 不可解析 (${missing.length}/${commands.length})` : 'MCP command 均可解析',
-      details: `文件: ${config.path}\n${missing.length ? `不可解析:\n${missing.join('\n')}` : commands.join('\n')}`,
+      detail: `文件: ${config.path}\n${missing.length ? `不可解析:\n${missing.join('\n')}` : commands.join('\n')}`,
     };
   },
 };

--- a/src/scanners/mcp-config-health.ts
+++ b/src/scanners/mcp-config-health.ts
@@ -10,7 +10,7 @@ const scanner: Scanner = {
   async scan(): Promise<ScanResult> {
     const config = readJsonCandidate([...getClaudeMcpConfigCandidates(), ...getMcpConfigCandidates()]);
     if (!config) return { id: this.id, name: this.name, category: this.category, status: 'unknown', message: '未发现 MCP 配置文件' };
-    if (config.error) return { id: this.id, name: this.name, category: this.category, status: 'fail', error_type: 'misconfigured', message: 'MCP 配置无法解析', details: `文件: ${config.path}\n错误: ${config.error}` };
+    if (config.error) return { id: this.id, name: this.name, category: this.category, status: 'fail', error_type: 'misconfigured', message: 'MCP 配置无法解析', detail: `文件: ${config.path}\n错误: ${config.error}` };
 
     const servers = config.data?.mcpServers || config.data?.servers || {};
     const serverCount = servers && typeof servers === 'object' ? Object.keys(servers).length : 0;
@@ -20,7 +20,7 @@ const scanner: Scanner = {
       status: placeholders.length ? 'warn' : 'pass',
       error_type: placeholders.length ? 'misconfigured' : undefined,
       message: placeholders.length ? 'MCP 配置中存在疑似占位密钥' : `MCP 配置可解析（${serverCount} 个 server）`,
-      details: `文件: ${config.path}${placeholders.length ? `\n占位项: ${placeholders.map(item => item.key).join(', ')}` : ''}`,
+      detail: `文件: ${config.path}${placeholders.length ? `\n占位项: ${placeholders.map(item => item.key).join(', ')}` : ''}`,
     };
   },
 };

--- a/src/scanners/mirror-sources.ts
+++ b/src/scanners/mirror-sources.ts
@@ -8,20 +8,20 @@ const scanner: Scanner = {
   category: 'network',
 
   async scan(): Promise<ScanResult> {
-    const details: string[] = [];
-    if (commandExists('npm')) details.push(`npm: ${runCommand('npm config get registry', 5000).stdout}`);
-    if (commandExists('pip')) details.push(`pip: ${runCommand('pip config get global.index-url 2>/dev/null', 5000).stdout || '(默认)'}`);
-    if (commandExists('brew')) details.push(`brew: ${runCommand('brew --repo', 5000).stdout}`);
-    if (commandExists('uv')) details.push(`uv: ${process.env.UV_DEFAULT_INDEX || process.env.UV_INDEX_URL || '(默认)'}`);
+    const detail: string[] = [];
+    if (commandExists('npm')) detail.push(`npm: ${runCommand('npm config get registry', 5000).stdout}`);
+    if (commandExists('pip')) detail.push(`pip: ${runCommand('pip config get global.index-url 2>/dev/null', 5000).stdout || '(默认)'}`);
+    if (commandExists('brew')) detail.push(`brew: ${runCommand('brew --repo', 5000).stdout}`);
+    if (commandExists('uv')) detail.push(`uv: ${process.env.UV_DEFAULT_INDEX || process.env.UV_INDEX_URL || '(默认)'}`);
 
-    const text = details.join('\n');
+    const text = detail.join('\n');
     const usesMirror = /(npmmirror|tuna|aliyun|ustc|sjtu|pku|douban)/i.test(text);
     return {
       id: this.id, name: this.name, category: this.category,
-      status: details.length ? 'pass' : 'unknown',
-      message: usesMirror ? '检测到国内镜像源配置' : (details.length ? '未检测到显式镜像源配置（非必需）' : 'npm/pip/brew/uv 均不可用'),
-      error_type: details.length ? undefined : 'misconfigured',
-      details: text || 'npm/pip/brew/uv 均不可用，无法检查镜像源。',
+      status: detail.length ? 'pass' : 'unknown',
+      message: usesMirror ? '检测到国内镜像源配置' : (detail.length ? '未检测到显式镜像源配置（非必需）' : 'npm/pip/brew/uv 均不可用'),
+      error_type: detail.length ? undefined : 'misconfigured',
+      detail: text || 'npm/pip/brew/uv 均不可用，无法检查镜像源。',
     };
   },
 };

--- a/src/scanners/node-global-bin-path.ts
+++ b/src/scanners/node-global-bin-path.ts
@@ -18,7 +18,7 @@ const scanner: Scanner = {
       status: inPath ? 'pass' : 'warn',
       error_type: inPath ? undefined : 'misconfigured',
       message: inPath ? 'Node 全局 bin 已在 PATH 中' : 'Node 全局 bin 可能未加入 PATH',
-      details: `prefix: ${prefix}\nbin: ${bin}`,
+      detail: `prefix: ${prefix}\nbin: ${bin}`,
     };
   },
 };

--- a/src/scanners/node-manager-conflict.ts
+++ b/src/scanners/node-manager-conflict.ts
@@ -16,7 +16,7 @@ const scanner: Scanner = {
       status: managers.length > 1 ? 'warn' : 'pass',
       error_type: managers.length > 1 ? 'conflict' : undefined,
       message: managers.length > 1 ? `检测到多个 Node 版本管理器: ${managers.join(', ')}` : `Node 版本管理器正常${managers.length ? ` (${managers[0]})` : ''}`,
-      details: `node: ${nodePath || '(未检测到)'}\nnpm: ${npmPath || '(未检测到)'}`,
+      detail: `node: ${nodePath || '(未检测到)'}\nnpm: ${npmPath || '(未检测到)'}`,
     };
   },
 };

--- a/src/scanners/node-version.ts
+++ b/src/scanners/node-version.ts
@@ -12,16 +12,23 @@ const scanner: Scanner = {
     if (exitCode !== 0) {
       return { id: this.id, name: this.name, category: this.category, status: 'fail',
         error_type: 'missing',
+        fixCommand: 'curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.0/install.sh | bash && nvm install --lts',
+        severity: 'high',
         message: 'Node.js 未安装。建议用 nvm: curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.0/install.sh | bash' };
     }
     const version = stdout.trim();
+    const nodePath = runCommand('which node', 3000).stdout.trim() || null;
     const major = parseInt(version.replace('v', '').split('.')[0]);
     if (major < 18) {
       return { id: this.id, name: this.name, category: this.category, status: 'warn',
         error_type: 'outdated',
+        version, path: nodePath,
+        fixCommand: 'nvm install --lts',
+        severity: 'medium',
         message: `Node.js ${version} 过旧（建议 18+）` };
     }
     return { id: this.id, name: this.name, category: this.category, status: 'pass',
+      version, path: nodePath,
       message: `Node.js ${version}` };
   },
 };

--- a/src/scanners/openclaw-config-health.ts
+++ b/src/scanners/openclaw-config-health.ts
@@ -15,9 +15,9 @@ const scanner: Scanner = {
       return { id: this.id, name: this.name, category: this.category, status: installed ? 'warn' : 'unknown', message: installed ? 'OpenClaw 已安装，但未发现配置文件' : '未检测到 OpenClaw 配置' };
     }
     if (config.error) {
-      return { id: this.id, name: this.name, category: this.category, status: 'fail', error_type: 'misconfigured', message: 'OpenClaw 配置无法解析', details: `文件: ${config.path}\n错误: ${config.error}` };
+      return { id: this.id, name: this.name, category: this.category, status: 'fail', error_type: 'misconfigured', message: 'OpenClaw 配置无法解析', detail: `文件: ${config.path}\n错误: ${config.error}` };
     }
-    return { id: this.id, name: this.name, category: this.category, status: 'pass', message: 'OpenClaw 配置文件可解析', details: `文件: ${config.path}` };
+    return { id: this.id, name: this.name, category: this.category, status: 'pass', message: 'OpenClaw 配置文件可解析', detail: `文件: ${config.path}` };
   },
 };
 

--- a/src/scanners/package-managers.ts
+++ b/src/scanners/package-managers.ts
@@ -12,11 +12,11 @@ const scanner: Scanner = {
     if (managers.length === 0) {
       return { id: this.id, name: this.name, category: this.category, status: 'fail', message: '未检测到常用包管理器', error_type: 'missing', suggestions: ['安装 Homebrew: /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"'] };
     }
-    const details = managers.map(cmd => `${cmd}: ${runCommand(`${cmd} --version`, 5000).stdout.split('\n')[0] || '可用'}`).join('\n');
+    const detail = managers.map(cmd => `${cmd}: ${runCommand(`${cmd} --version`, 5000).stdout.split('\n')[0] || '可用'}`).join('\n');
     if (managers.includes('brew')) {
-      return { id: this.id, name: this.name, category: this.category, status: 'pass', message: `检测到包管理器: ${managers.join(', ')}`, details };
+      return { id: this.id, name: this.name, category: this.category, status: 'pass', message: `检测到包管理器: ${managers.join(', ')}`, detail };
     }
-    return { id: this.id, name: this.name, category: this.category, status: 'warn', message: `检测到包管理器: ${managers.join(', ')}（缺少 Homebrew）`, details, error_type: 'missing' };
+    return { id: this.id, name: this.name, category: this.category, status: 'warn', message: `检测到包管理器: ${managers.join(', ')}（缺少 Homebrew）`, detail, error_type: 'missing' };
   },
 };
 

--- a/src/scanners/path-chinese.ts
+++ b/src/scanners/path-chinese.ts
@@ -10,7 +10,7 @@ const scanner: Scanner = {
     const targets = [process.cwd(), process.env.HOME || '', process.env.SHELL || ''].filter(Boolean);
     const withCjk = targets.filter(value => /[\u4e00-\u9fff]/.test(value));
     if (withCjk.length > 0) {
-      return { id: this.id, name: this.name, category: this.category, status: 'warn', error_type: 'misconfigured', message: '关键路径包含中文字符，少数旧工具可能兼容性较差', details: withCjk.join('\n') };
+      return { id: this.id, name: this.name, category: this.category, status: 'warn', error_type: 'misconfigured', message: '关键路径包含中文字符，少数旧工具可能兼容性较差', detail: withCjk.join('\n') };
     }
     return { id: this.id, name: this.name, category: this.category, status: 'pass', message: '关键路径未发现中文字符' };
   },

--- a/src/scanners/path-spaces.ts
+++ b/src/scanners/path-spaces.ts
@@ -10,7 +10,7 @@ const scanner: Scanner = {
     const paths = [process.cwd(), ...(process.env.PATH || '').split(':')].filter(Boolean);
     const withSpaces = paths.filter(value => /\s/.test(value));
     if (withSpaces.length > 0) {
-      return { id: this.id, name: this.name, category: this.category, status: 'warn', error_type: 'misconfigured', message: `发现 ${withSpaces.length} 个包含空格的路径`, details: withSpaces.slice(0, 20).join('\n') };
+      return { id: this.id, name: this.name, category: this.category, status: 'warn', error_type: 'misconfigured', message: `发现 ${withSpaces.length} 个包含空格的路径`, detail: withSpaces.slice(0, 20).join('\n') };
     }
     return { id: this.id, name: this.name, category: this.category, status: 'pass', message: 'PATH 与当前目录未发现空格路径' };
   },

--- a/src/scanners/powershell-policy.ts
+++ b/src/scanners/powershell-policy.ts
@@ -16,7 +16,7 @@ const scanner: Scanner = {
       status: zshNoGlobalRcs ? 'pass' : 'warn',
       error_type: zshNoGlobalRcs ? undefined : 'misconfigured',
       message: zshNoGlobalRcs ? 'macOS Shell 脚本执行正常' : 'zsh 基础启动异常，可能影响安装脚本',
-      details: `SHELL: ${shell || '(未设置)'}\npwsh: ${pwsh ? '已安装' : '未安装，macOS 通常不需要 PowerShell 执行策略'}\nzsh -f: ${zshNoGlobalRcs ? '正常' : '异常'}`,
+      detail: `SHELL: ${shell || '(未设置)'}\npwsh: ${pwsh ? '已安装' : '未安装，macOS 通常不需要 PowerShell 执行策略'}\nzsh -f: ${zshNoGlobalRcs ? '正常' : '异常'}`,
     };
   },
 };

--- a/src/scanners/powershell-version.ts
+++ b/src/scanners/powershell-version.ts
@@ -12,9 +12,9 @@ const scanner: Scanner = {
     const bashVersion = runCommand('bash --version', 3000).stdout.split('\n')[0]?.trim() || '';
     if (commandExists('pwsh')) {
       const pwsh = runCommand('pwsh -NoProfile -Command "$PSVersionTable.PSVersion.ToString()"', 8000).stdout.trim();
-      return { id: this.id, name: this.name, category: this.category, status: 'pass', message: `PowerShell ${pwsh} 可用`, details: `zsh: ${zshVersion}\nbash: ${bashVersion}` };
+      return { id: this.id, name: this.name, category: this.category, status: 'pass', message: `PowerShell ${pwsh} 可用`, detail: `zsh: ${zshVersion}\nbash: ${bashVersion}` };
     }
-    return { id: this.id, name: this.name, category: this.category, status: 'pass', message: 'macOS 默认 Shell 可用', details: `zsh: ${zshVersion}\nbash: ${bashVersion}\nPowerShell 不是 macOS AI 开发必需项。` };
+    return { id: this.id, name: this.name, category: this.category, status: 'pass', message: 'macOS 默认 Shell 可用', detail: `zsh: ${zshVersion}\nbash: ${bashVersion}\nPowerShell 不是 macOS AI 开发必需项。` };
   },
 };
 

--- a/src/scanners/python-env-alignment.ts
+++ b/src/scanners/python-env-alignment.ts
@@ -19,7 +19,7 @@ const scanner: Scanner = {
     const python = runCommand('python3 -c "import sys; print(sys.executable)"', 8000);
     const pip = runCommand('python3 -m pip --version', 8000);
     if (python.exitCode !== 0) return { id: this.id, name: this.name, category: this.category, status: 'fail', error_type: 'missing', message: 'python3 不可用，无法校验项目环境' };
-    if (pip.exitCode !== 0) return { id: this.id, name: this.name, category: this.category, status: 'warn', error_type: 'misconfigured', message: 'pip 不可用，Python 依赖安装可能失败', details: `python: ${python.stdout.trim()}` };
+    if (pip.exitCode !== 0) return { id: this.id, name: this.name, category: this.category, status: 'warn', error_type: 'misconfigured', message: 'pip 不可用，Python 依赖安装可能失败', detail: `python: ${python.stdout.trim()}` };
 
     const pythonPath = python.stdout.split(/\r?\n/)[0].trim();
     const pipPath = pip.stdout.match(/from\s+(.+?)\s+\(python/i)?.[1]?.trim() || '';
@@ -29,7 +29,7 @@ const scanner: Scanner = {
       status: aligned ? 'pass' : 'warn',
       error_type: aligned ? undefined : 'misconfigured',
       message: aligned ? 'python3 与 pip 环境一致' : 'python3 与 pip 可能来自不同环境',
-      details: `python3: ${pythonPath}\npip: ${pipPath || pip.stdout.trim()}`,
+      detail: `python3: ${pythonPath}\npip: ${pipPath || pip.stdout.trim()}`,
     };
   },
 };

--- a/src/scanners/python-project-venv.ts
+++ b/src/scanners/python-project-venv.ts
@@ -13,8 +13,8 @@ const scanner: Scanner = {
   async scan(): Promise<ScanResult> {
     if (!hasProjectMarker(PYTHON_PROJECT_MARKERS)) return { id: this.id, name: this.name, category: this.category, status: 'unknown', message: '当前目录未检测到 Python 项目' };
     const venvDir = findProjectDir(VENV_DIRS);
-    if (!venvDir) return { id: this.id, name: this.name, category: this.category, status: 'warn', error_type: 'misconfigured', message: '检测到 Python 项目，但未发现项目级虚拟环境', details: '建议在项目根目录创建 .venv，或使用 uv/poetry 管理环境。' };
-    return { id: this.id, name: this.name, category: this.category, status: 'pass', message: '检测到项目级 Python 虚拟环境', details: `目录: ${venvDir}` };
+    if (!venvDir) return { id: this.id, name: this.name, category: this.category, status: 'warn', error_type: 'misconfigured', message: '检测到 Python 项目，但未发现项目级虚拟环境', detail: '建议在项目根目录创建 .venv，或使用 uv/poetry 管理环境。' };
+    return { id: this.id, name: this.name, category: this.category, status: 'pass', message: '检测到项目级 Python 虚拟环境', detail: `目录: ${venvDir}` };
   },
 };
 

--- a/src/scanners/python-versions.ts
+++ b/src/scanners/python-versions.ts
@@ -11,17 +11,24 @@ const scanner: Scanner = {
     if (!commandExists('python3')) {
       return { id: this.id, name: this.name, category: this.category, status: 'fail',
         error_type: 'missing',
+        fixCommand: 'brew install python@3.12',
+        severity: 'high',
         message: 'Python3 未安装。建议: brew install python@3.12' };
     }
     const { stdout } = runCommand('python3 --version', 5000);
-    const version = stdout.trim();
-    const major = parseInt(version.replace('Python ', '').split('.')[0]);
+    const version = stdout.trim().replace('Python ', '');
+    const pythonPath = runCommand('which python3', 3000).stdout.trim() || null;
+    const major = parseInt(version.split('.')[0]);
     if (major < 3 || (major === 3 && parseInt(version.split('.')[1]) < 10)) {
       return { id: this.id, name: this.name, category: this.category, status: 'warn',
         error_type: 'outdated',
+        version, path: pythonPath,
+        fixCommand: 'brew upgrade python@3.12',
+        severity: 'medium',
         message: `Python ${version} 过旧（建议 3.10+）` };
     }
     return { id: this.id, name: this.name, category: this.category, status: 'pass',
+      version, path: pythonPath,
       message: `Python ${version}` };
   },
 };

--- a/src/scanners/shell-encoding-health.ts
+++ b/src/scanners/shell-encoding-health.ts
@@ -17,7 +17,7 @@ const scanner: Scanner = {
       status: utf8 ? 'pass' : 'warn',
       error_type: utf8 ? undefined : 'misconfigured',
       message: utf8 ? '终端 locale 使用 UTF-8' : '终端 locale 未明确使用 UTF-8，可能出现中文或 JSON 输出乱码',
-      details: `LANG=${lang || '(未设置)'}\nLC_ALL=${lcAll || '(未设置)'}\n${locale}`,
+      detail: `LANG=${lang || '(未设置)'}\nLC_ALL=${lcAll || '(未设置)'}\n${locale}`,
     };
   },
 };

--- a/src/scanners/site-reachability.ts
+++ b/src/scanners/site-reachability.ts
@@ -24,11 +24,11 @@ const scanner: Scanner = {
 
     if (unreachable.length === sites.length) {
       return { id: this.id, name: this.name, category: this.category, status: 'fail',
-        error_type: 'network', message: '所有 AI 站点不可达', details: '请检查网络连接或代理设置。' };
+        error_type: 'network', message: '所有 AI 站点不可达', detail: '请检查网络连接或代理设置。' };
     }
     if (unreachable.length > 0) {
       return { id: this.id, name: this.name, category: this.category, status: 'warn',
-        error_type: 'network', message: `不可达: ${unreachable.join(', ')}`, details: `可达: ${reachable.join(', ')}` };
+        error_type: 'network', message: `不可达: ${unreachable.join(', ')}`, detail: `可达: ${reachable.join(', ')}` };
     }
     return { id: this.id, name: this.name, category: this.category, status: 'pass', message: '所有 AI 站点可达' };
   },

--- a/src/scanners/temp-space.ts
+++ b/src/scanners/temp-space.ts
@@ -13,13 +13,13 @@ const scanner: Scanner = {
     const parts = output.trim().split(/\s+/);
     const availableKb = parseInt(parts[3] || '0', 10);
     const freeGb = Math.round(availableKb / 1024 / 1024);
-    if (!availableKb) return { id: this.id, name: this.name, category: this.category, status: 'unknown', message: '无法读取临时目录剩余空间', details: `TMPDIR: ${tempDir}` };
+    if (!availableKb) return { id: this.id, name: this.name, category: this.category, status: 'unknown', message: '无法读取临时目录剩余空间', detail: `TMPDIR: ${tempDir}` };
     return {
       id: this.id, name: this.name, category: this.category,
       status: freeGb < 10 ? 'fail' : 'pass',
       error_type: freeGb < 10 ? 'resource' : undefined,
       message: freeGb < 10 ? `临时目录所在磁盘空间不足 (${freeGb} GB < 10 GB)` : `临时目录所在磁盘空间充足 (${freeGb} GB)`,
-      details: `TMPDIR: ${tempDir}\n${output}`,
+      detail: `TMPDIR: ${tempDir}\n${output}`,
     };
   },
 };

--- a/src/scanners/terminal-profile-health.ts
+++ b/src/scanners/terminal-profile-health.ts
@@ -32,7 +32,7 @@ const scanner: Scanner = {
       status: suspicious.length ? 'warn' : (modernShell ? 'pass' : 'unknown'),
       error_type: suspicious.length ? 'misconfigured' : undefined,
       message: suspicious.length ? 'Shell 启动配置存在潜在问题' : `默认 Shell 配置正常 (${shell || 'unknown'})`,
-      details: `HOME: ${home}\nSHELL: ${shell || '(未设置)'}\n启动文件:\n${startupFiles.join('\n') || '(未发现)'}${suspicious.length ? `\n\n问题:\n${suspicious.join('\n')}` : ''}`,
+      detail: `HOME: ${home}\nSHELL: ${shell || '(未设置)'}\n启动文件:\n${startupFiles.join('\n') || '(未发现)'}${suspicious.length ? `\n\n问题:\n${suspicious.join('\n')}` : ''}`,
     };
   },
 };

--- a/src/scanners/time-sync.ts
+++ b/src/scanners/time-sync.ts
@@ -25,7 +25,7 @@ const scanner: Scanner = {
       status: enabled && !highOffset ? 'pass' : 'warn',
       error_type: enabled && !highOffset ? undefined : 'misconfigured',
       message: enabled && !highOffset ? '系统时间同步正常' : '时间同步未开启或偏移可能过大',
-      details: `网络时间: ${setup.stdout || '(无法读取)'}\n时间服务器: ${server.stdout || '(无法读取)'}\nsntp:\n${sntp.stdout || '(无法读取)'}`,
+      detail: `网络时间: ${setup.stdout || '(无法读取)'}\n时间服务器: ${server.stdout || '(无法读取)'}\nsntp:\n${sntp.stdout || '(无法读取)'}`,
       suggestions: enabled ? undefined : ['sudo systemsetup -setusingnetworktime on'],
     };
   },

--- a/src/scanners/types.ts
+++ b/src/scanners/types.ts
@@ -18,9 +18,17 @@ export interface ScanResult {
   category: ScannerCategory;
   status: 'pass' | 'warn' | 'fail' | 'unknown';
   message: string;
-  details?: string;
+  detail?: string;
   suggestions?: string[];
   error_type?: ErrorType;
+  /** 工具/软件版本 */
+  version?: string | null;
+  /** 安装路径 */
+  path?: string | null;
+  /** 修复命令 */
+  fixCommand?: string | null;
+  /** 严重程度: low / medium / high / critical */
+  severity?: string | null;
 }
 
 export type ScannerResult = ScanResult;

--- a/src/scanners/unix-commands.ts
+++ b/src/scanners/unix-commands.ts
@@ -16,7 +16,7 @@ const scanner: Scanner = {
       return { id: this.id, name: this.name, category: this.category, status: 'fail', error_type: 'missing', message: '所有常用 Unix 命令均不可用' };
     }
     if (missing.length > 0) {
-      return { id: this.id, name: this.name, category: this.category, status: 'warn', error_type: 'missing', message: `缺少命令: ${missing.join(', ')}`, details: `可用: ${available.join(', ')}` };
+      return { id: this.id, name: this.name, category: this.category, status: 'warn', error_type: 'missing', message: `缺少命令: ${missing.join(', ')}`, detail: `可用: ${available.join(', ')}` };
     }
     return { id: this.id, name: this.name, category: this.category, status: 'pass', message: `所有 Unix 命令可用 (${available.join(', ')})` };
   },

--- a/src/scanners/virtualization.ts
+++ b/src/scanners/virtualization.ts
@@ -21,14 +21,14 @@ const scanner: Scanner = {
     ].filter(Boolean);
 
     if (!hasHypervisor) {
-      return { id: this.id, name: this.name, category: this.category, status: 'warn', error_type: 'incompatible', message: '未确认硬件虚拟化支持', details: `CPU features: ${cpuFeatures || '(无)'}` };
+      return { id: this.id, name: this.name, category: this.category, status: 'warn', error_type: 'incompatible', message: '未确认硬件虚拟化支持', detail: `CPU features: ${cpuFeatures || '(无)'}` };
     }
 
     return {
       id: this.id, name: this.name, category: this.category,
       status: 'pass',
       message: tools.length ? `虚拟化可用，已检测到 ${tools.join(', ')}` : '硬件虚拟化能力可用',
-      details: isAppleSilicon ? 'Apple Silicon 支持 Virtualization.framework；可使用 UTM、Docker Desktop 或 Parallels。' : `CPU features: ${cpuFeatures}`,
+      detail: isAppleSilicon ? 'Apple Silicon 支持 Virtualization.framework；可使用 UTM、Docker Desktop 或 Parallels。' : `CPU features: ${cpuFeatures}`,
     };
   },
 };

--- a/src/scanners/vram-usage.ts
+++ b/src/scanners/vram-usage.ts
@@ -32,7 +32,7 @@ const scanner: Scanner = {
       status: usedPct > 90 ? 'warn' : 'pass',
       error_type: usedPct > 90 ? 'resource' : undefined,
       message: usedPct > 90 ? `统一内存使用率偏高 (${usedPct}%)，可能影响本地模型推理` : `统一内存压力正常 (${usedPct}%)`,
-      details: `总内存: ${Math.round(totalBytes / 1024 ** 3)} GB\n估算可用: ${Math.round(availableBytes / 1024 ** 3)} GB\n${gpuInfo}`,
+      detail: `总内存: ${Math.round(totalBytes / 1024 ** 3)} GB\n估算可用: ${Math.round(availableBytes / 1024 ** 3)} GB\n${gpuInfo}`,
     };
   },
 };

--- a/src/scanners/wsl-version.ts
+++ b/src/scanners/wsl-version.ts
@@ -28,7 +28,7 @@ const scanner: Scanner = {
       status: rosetta || linuxTools.length > 0 ? 'pass' : 'warn',
       error_type: rosetta || linuxTools.length > 0 ? undefined : 'incompatible',
       message: rosetta ? 'Rosetta 2 已安装，可运行多数 x86_64 macOS CLI' : '未检测到 Rosetta 2 或虚拟 Linux 工具',
-      details: `虚拟 Linux 工具: ${linuxTools.length ? linuxTools.join(', ') : '(未检测到)'}`,
+      detail: `虚拟 Linux 工具: ${linuxTools.length ? linuxTools.join(', ') : '(未检测到)'}`,
       suggestions: rosetta ? undefined : ['softwareupdate --install-rosetta --agree-to-license', 'brew install --cask utm'],
     };
   },

--- a/src/scanners/xcode.ts
+++ b/src/scanners/xcode.ts
@@ -9,18 +9,21 @@ const scanner: Scanner = {
 
   async scan(): Promise<ScanResult> {
     // First check: does xcode-select -p succeed?
-    const { exitCode: xcodeExit } = runCommand('xcode-select -p', 3000);
+    const { stdout: pathOutput, exitCode: xcodeExit } = runCommand('xcode-select -p', 3000);
     if (xcodeExit !== 0) {
       return {
         id: this.id, name: this.name, category: this.category, status: 'fail',
         error_type: 'missing',
+        fixCommand: 'xcode-select --install',
+        severity: 'high',
         message: 'Xcode Command Line Tools 未安装。安装命令: xcode-select --install',
       };
     }
-    const { stdout } = runCommand('xcode-select -p', 3000);
+    const xcodePath = pathOutput.trim() || null;
     return {
       id: this.id, name: this.name, category: this.category, status: 'pass',
-      message: `Xcode CLT 已安装: ${stdout.trim()}`,
+      path: xcodePath,
+      message: `Xcode CLT 已安装: ${xcodePath}`,
     };
   },
 };


### PR DESCRIPTION
## Summary
- 修复 `details` → `detail` 字段名不匹配（后端完全忽略 details 字段）
- 新增 version, path, fixCommand, severity 到 ScanResult 接口
- 5 个核心扫描器（python, node, git, homebrew, xcode）已填充新字段
- createPayload 现在上传所有字段到 stash API

## Test plan
- [x] TypeScript 编译通过（8 个 pre-existing 警告）
- [ ] 实际扫描测试验证字段正确传输

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)