### PR TITLE
fix: align AICOEVO payload and bounty auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ mac-aicheck/
 
 | 变量 | 默认值 | 说明 |
 |------|--------|------|
-| `AICO_EVO_URL` | `https://aicoevo.com` | AICO EVO API 地址 |
+| `AICO_EVO_URL` | `https://aicoevo.net` | AICO EVO API 地址 |
 | `AICO_EVO_TOKEN` | — | 上报认证 Token |
 | `PORT` | `7890` | Web 服务端口 |
 

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -397,6 +397,11 @@ function apiBase() {
   return raw.endsWith('/api/v1') ? raw : `${raw}/api/v1`;
 }
 
+function agentApiKeyHeaders(config: { authToken?: string }): Record<string, string> | null {
+  if (!config.authToken || !config.authToken.startsWith('ak_')) return null;
+  return { 'X-API-Key': config.authToken };
+}
+
 async function requestJson(url: string, init: { method?: string; headers?: Record<string, string>; body?: unknown; timeoutMs?: number } = {}) {
   const resp = await fetch(url, { method: init.method || 'GET', headers: { Accept: 'application/json', ...(init.body ? { 'Content-Type': 'application/json' } : {}), ...(init.headers || {}) }, body: init.body ? JSON.stringify(init.body) : undefined, signal: AbortSignal.timeout(init.timeoutMs || 5000) });
   const text = await resp.text();
@@ -1078,13 +1083,14 @@ async function main(argv: string[]) {
   // ── Bounty commands: list, recommended ──
   if (command === 'bounty-list') {
     const cfg = loadConfig();
-    if (!cfg.authToken) { process.stdout.write('未登录，请先运行 mac-aicheck agent auth\n'); return 1; }
+    const headers = agentApiKeyHeaders(cfg);
+    if (!headers) { process.stdout.write('悬赏命令需要 Agent API Key，请先运行 mac-aicheck agent bind\n'); return 1; }
     const page = String(args.page || '1');
     const pageSize = String(args.limit || '10');
     const sortBy = String(args.sort || 'reward');
     try {
       const result = await requestJson(`${apiBase()}/agent/bounties?page=${page}&page_size=${pageSize}&sort_by=${sortBy}`, {
-        headers: { 'Authorization': `Bearer ${cfg.authToken}`, 'X-API-Key': cfg.authToken },
+        headers,
       });
       process.stdout.write(JSON.stringify(result.data, null, 2) + '\n');
     } catch (e: unknown) { process.stdout.write(`获取悬赏列表失败: ${(e as Error).message}\n`); return 1; }
@@ -1093,12 +1099,13 @@ async function main(argv: string[]) {
 
   if (command === 'bounty-recommended') {
     const cfg = loadConfig();
-    if (!cfg.authToken) { process.stdout.write('未登录，请先运行 mac-aicheck agent auth\n'); return 1; }
+    const headers = agentApiKeyHeaders(cfg);
+    if (!headers) { process.stdout.write('悬赏命令需要 Agent API Key，请先运行 mac-aicheck agent bind\n'); return 1; }
     const strategy = String(args.strategy || 'balanced');
     const limit = String(args.limit || '10');
     try {
       const result = await requestJson(`${apiBase()}/agent/bounties/recommended?strategy=${strategy}&limit=${limit}`, {
-        headers: { 'Authorization': `Bearer ${cfg.authToken}`, 'X-API-Key': cfg.authToken },
+        headers,
       });
       process.stdout.write(JSON.stringify(result.data, null, 2) + '\n');
     } catch (e: unknown) { process.stdout.write(`获取推荐悬赏失败: ${(e as Error).message}\n`); return 1; }
@@ -1108,13 +1115,14 @@ async function main(argv: string[]) {
   // ── Bounty: solve (KB 匹配获取答案) ──
   if (command === 'bounty-solve') {
     const cfg = loadConfig();
-    if (!cfg.authToken) { process.stdout.write('未登录，请先运行 mac-aicheck agent auth\n'); return 1; }
+    const headers = agentApiKeyHeaders(cfg);
+    if (!headers) { process.stdout.write('悬赏命令需要 Agent API Key，请先运行 mac-aicheck agent bind\n'); return 1; }
     const id = (args._ as string[])[0];
     if (!id) { process.stdout.write('用法: mac-aicheck agent bounty-solve <id>\n'); return 1; }
     try {
       const result = await requestJson(`${apiBase()}/agent/bounties/${id}/auto-solve`, {
         method: 'POST',
-        headers: { 'Authorization': `Bearer ${cfg.authToken}`, 'X-API-Key': cfg.authToken },
+        headers,
       });
       if (result.status >= 400) { process.stdout.write(`KB 匹配失败: ${JSON.stringify(result.data)}\n`); return 1; }
       process.stdout.write(JSON.stringify(result.data, null, 2) + '\n');
@@ -1125,13 +1133,14 @@ async function main(argv: string[]) {
   // ── Bounty: claim (认领悬赏) ──
   if (command === 'bounty-claim') {
     const cfg = loadConfig();
-    if (!cfg.authToken) { process.stdout.write('未登录，请先运行 mac-aicheck agent auth\n'); return 1; }
+    const headers = agentApiKeyHeaders(cfg);
+    if (!headers) { process.stdout.write('悬赏命令需要 Agent API Key，请先运行 mac-aicheck agent bind\n'); return 1; }
     const id = (args._ as string[])[0];
     if (!id) { process.stdout.write('用法: mac-aicheck agent bounty-claim <id>\n'); return 1; }
     try {
       const result = await requestJson(`${apiBase()}/agent/bounties/${id}/claim`, {
         method: 'POST',
-        headers: { 'Authorization': `Bearer ${cfg.authToken}`, 'X-API-Key': cfg.authToken },
+        headers,
       });
       if (result.status >= 400) { process.stdout.write(`认领失败: ${JSON.stringify(result.data)}\n`); return 1; }
       const d = result.data as Record<string, unknown>;
@@ -1143,14 +1152,15 @@ async function main(argv: string[]) {
   // ── Bounty: submit (提交回答) ──
   if (command === 'bounty-submit') {
     const cfg = loadConfig();
-    if (!cfg.authToken) { process.stdout.write('未登录，请先运行 mac-aicheck agent auth\n'); return 1; }
+    const headers = agentApiKeyHeaders(cfg);
+    if (!headers) { process.stdout.write('悬赏命令需要 Agent API Key，请先运行 mac-aicheck agent bind\n'); return 1; }
     const id = (args._ as string[])[0];
     const content = String(args.content || '');
     if (!id || !content) { process.stdout.write('用法: mac-aicheck agent bounty-submit <id> --content <text>\n'); return 1; }
     try {
       const result = await requestJson(`${apiBase()}/agent/bounties/${id}/submit`, {
         method: 'POST',
-        headers: { 'Authorization': `Bearer ${cfg.authToken}`, 'X-API-Key': cfg.authToken },
+        headers,
         body: { content, source: String(args.source || 'manual') },
       });
       if (result.status >= 400) { process.stdout.write(`提交失败: ${JSON.stringify(result.data)}\n`); return 1; }
@@ -1163,13 +1173,14 @@ async function main(argv: string[]) {
   // ── Bounty: release (释放认领) ──
   if (command === 'bounty-release') {
     const cfg = loadConfig();
-    if (!cfg.authToken) { process.stdout.write('未登录，请先运行 mac-aicheck agent auth\n'); return 1; }
+    const headers = agentApiKeyHeaders(cfg);
+    if (!headers) { process.stdout.write('悬赏命令需要 Agent API Key，请先运行 mac-aicheck agent bind\n'); return 1; }
     const id = (args._ as string[])[0];
     if (!id) { process.stdout.write('用法: mac-aicheck agent bounty-release <id>\n'); return 1; }
     try {
       const result = await requestJson(`${apiBase()}/agent/bounties/${id}/claim`, {
         method: 'DELETE',
-        headers: { 'Authorization': `Bearer ${cfg.authToken}`, 'X-API-Key': cfg.authToken },
+        headers,
       });
       if (result.status >= 400) { process.stdout.write(`释放失败: ${JSON.stringify(result.data)}\n`); return 1; }
       const d = result.data as Record<string, unknown>;
@@ -1181,11 +1192,12 @@ async function main(argv: string[]) {
   // ── Bounty: auto (自动循环: 推荐 → KB匹配 → claim+submit) ──
   if (command === 'bounty-auto') {
     const cfg = loadConfig();
-    if (!cfg.authToken) { process.stdout.write('未登录，请先运行 mac-aicheck agent auth\n'); return 1; }
+    const apiKeyHeaders = agentApiKeyHeaders(cfg);
+    if (!apiKeyHeaders) { process.stdout.write('悬赏命令需要 Agent API Key，请先运行 mac-aicheck agent bind\n'); return 1; }
     const interval = parseInt(String(args.interval || '300'), 10);
     const maxPerCycle = parseInt(String(args.limit || '3'), 10);
     const strategy = String(args.strategy || 'balanced');
-    const hdr = { 'Authorization': `Bearer ${cfg.authToken}`, 'X-API-Key': cfg.authToken };
+    const hdr = apiKeyHeaders;
 
     process.stdout.write(`bounty-auto 启动 (间隔 ${interval}s, 每轮最多 ${maxPerCycle})\n`);
 
@@ -1251,4 +1263,11 @@ async function main(argv: string[]) {
   throw new Error(`未知 agent 命令: ${command}`);
 }
 
-main(process.argv.slice(2)).then(code => { process.exitCode = typeof code === 'number' ? code : 0; }).catch(e => { console.error(`mac-aicheck Agent 错误: ${e.message}`); process.exitCode = 1; });
+export const _testHelpers = {
+  agentApiKeyHeaders,
+  loadConfig,
+};
+
+if (require.main === module) {
+  main(process.argv.slice(2)).then(code => { process.exitCode = typeof code === 'number' ? code : 0; }).catch(e => { console.error(`mac-aicheck Agent 错误: ${e.message}`); process.exitCode = 1; });
+}

--- a/src/api/aicoevo-client.ts
+++ b/src/api/aicoevo-client.ts
@@ -70,6 +70,7 @@ export interface AICOEVOPayload {
     status: string;
     message: string;
     detail?: string;
+    error_type?: string;
     suggestions?: string[];
     version?: string | null;
     path?: string | null;
@@ -162,6 +163,7 @@ export function createPayload(results: ScanResult[], score: ScoreResult): AICOEV
       status: r.status,
       message: sanitize(r.message),
       detail: r.detail ? sanitize(r.detail) : undefined,
+      error_type: r.error_type,
       suggestions: (r.suggestions || []).map(s => sanitize(s)),
       version: r.version ?? null,
       path: r.path ?? null,

--- a/src/scanners/ccswitch.ts
+++ b/src/scanners/ccswitch.ts
@@ -39,6 +39,7 @@ const scanner: Scanner = {
       id: this.id, name: this.name, category: this.category,
       status: 'warn',
       error_type: 'missing',
+      message: '未检测到 CCSwitch',
       detail: 'macOS 可优先使用 npm install -g ccswitch；若使用图形版，通常位于 /Applications 或 ~/Applications。',
       suggestions: ['npm install -g ccswitch'],
     };

--- a/src/scanners/claude-cli.ts
+++ b/src/scanners/claude-cli.ts
@@ -13,6 +13,7 @@ const scanner: Scanner = {
         id: this.id, name: this.name, category: this.category,
         status: 'warn',
         error_type: 'missing',
+        message: '未检测到 Claude Code CLI',
         detail: 'Claude Code 是 Anthropic 官方命令行 AI 编程助手。',
         suggestions: ['npm install -g @anthropic-ai/claude-code'],
       };

--- a/src/scanners/claude-config-health.ts
+++ b/src/scanners/claude-config-health.ts
@@ -27,6 +27,7 @@ const scanner: Scanner = {
         id: this.id, name: this.name, category: this.category,
         status: 'fail',
         error_type: 'misconfigured',
+        message: 'Claude Code 配置无法解析',
         detail: `文件: ${config.path}\n错误: ${config.error}`,
       };
     }

--- a/src/scanners/cpp-compiler.ts
+++ b/src/scanners/cpp-compiler.ts
@@ -20,6 +20,7 @@ const scanner: Scanner = {
       id: this.id, name: this.name, category: this.category,
       status: 'fail',
       error_type: 'missing',
+      message: '未检测到可用的 C/C++ 编译器',
       detail: 'macOS 上建议安装 Xcode Command Line Tools。',
       suggestions: ['xcode-select --install'],
     };

--- a/src/scanners/env-path-length.ts
+++ b/src/scanners/env-path-length.ts
@@ -15,10 +15,12 @@ const scanner: Scanner = {
     const warnLength = 8192;
 
     if (pathVar.length > warnLength || duplicates.length > 0) {
+      const issue = duplicates.length > 0 ? '存在重复 PATH 条目' : 'PATH 过长';
       return {
         id: this.id, name: this.name, category: this.category,
         status: 'warn',
         error_type: 'misconfigured',
+        message: issue,
         detail: duplicates.length ? `重复项:\n${duplicates.map(([p, c]) => `  ${p} (x${c})`).join('\n')}` : `建议低于 ${warnLength} 字符。`,
       };
     }

--- a/src/scanners/git-credential-health.ts
+++ b/src/scanners/git-credential-health.ts
@@ -21,6 +21,7 @@ const scanner: Scanner = {
         id: this.id, name: this.name, category: this.category,
         status: 'warn',
         error_type: 'misconfigured',
+        message: '未检测到 Git 凭据链路',
         detail: 'macOS 推荐使用 credential.helper=osxkeychain，或在 ~/.ssh 中配置 SSH Key。',
         suggestions: ['git config --global credential.helper osxkeychain', 'ssh-keygen -t ed25519 -C "you@example.com"'],
       };

--- a/src/scanners/git-path.ts
+++ b/src/scanners/git-path.ts
@@ -19,6 +19,7 @@ const scanner: Scanner = {
         id: this.id, name: this.name, category: this.category,
         status: 'fail',
         error_type: 'missing',
+        message: `Git 依赖命令缺失: ${missing.join(', ')}`,
         detail: `git: ${gitPath}`,
       };
     }

--- a/src/scanners/uv-package-manager.ts
+++ b/src/scanners/uv-package-manager.ts
@@ -13,6 +13,7 @@ const scanner: Scanner = {
         id: this.id, name: this.name, category: this.category,
         status: 'warn',
         error_type: 'missing',
+        message: '未检测到 uv 包管理器',
         suggestions: ['curl -LsSf https://astral.sh/uv/install.sh | sh', 'brew install uv', 'pip install uv'],
       };
     }

--- a/tests/aicoevo-contract.test.ts
+++ b/tests/aicoevo-contract.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import { createPayload } from '../src/api/aicoevo-client';
+import { _testHelpers } from '../src/agent/index';
+import type { ScanResult } from '../src/scanners/types';
+
+describe('AICOEVO contract alignment', () => {
+  it('includes error_type in uploaded scan payload', () => {
+    const results: ScanResult[] = [
+      {
+        id: 'python-versions',
+        name: 'Python',
+        category: 'toolchain',
+        status: 'fail',
+        message: 'Python 版本过旧',
+        error_type: 'outdated',
+      },
+    ];
+
+    const payload = createPayload(results, { score: 42 } as { score: number });
+
+    expect(payload.results[0].error_type).toBe('outdated');
+  });
+
+  it('only treats ak_ tokens as bounty-capable API keys', () => {
+    expect(_testHelpers.agentApiKeyHeaders({ authToken: 'ak_live_123' })).toEqual({
+      'X-API-Key': 'ak_live_123',
+    });
+    expect(_testHelpers.agentApiKeyHeaders({ authToken: 'jwt-token' })).toBeNull();
+    expect(_testHelpers.agentApiKeyHeaders({})).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- include `error_type` in the scan payload sent to AICOEVO so macOS uploads match the backend matching and bounty grouping contract
- restrict bounty-related agent commands to bound `ak_` API keys instead of sending both JWT and API-key headers
- correct the default AICO EVO README domain from `.com` to `.net`
- add regression tests for payload shape and API-key bounty auth gating

## Why
AICOEVO now uses `error_type` during scan matching and bounty grouping. Mac uploads were dropping that field, so they were accepted but matched with lower fidelity than WinAICheck. Bounty commands also needed the same API-key guard as the Windows agent.

## Verification
- `npm test -- tests/aicoevo-contract.test.ts`
- Result: `2 passed`
- Note: the test run prints a harmless `sw_vers` warning on Windows because system-info collection is macOS-specific
