### PR TITLE
fix: switch uploads to scan intake

### DIFF
--- a/dist/api/aicoevo-client.d.ts
+++ b/dist/api/aicoevo-client.d.ts
@@ -4,7 +4,7 @@
  * 基础URL: https://aicoevo.net (环境变量 AICO_EVO_URL 配置)
  *
  * 与 WinAICheck 对齐的流程:
- * 1. stash: POST /api/v1/stash → 获取 token（无需登录）
+ * 1. scan-intake: POST /api/v1/problem-briefs/scan-intake → 获取 token + problem brief（无需登录）
  * 2. claim: 浏览器打开 https://aicoevo.net/claim?t=TOKEN
  * 3. feedback: POST /api/v1/feedback（无需登录）
  */
@@ -40,9 +40,13 @@ export interface StashRequest {
 }
 export interface StashResponse {
     token: string;
+    claim_url?: string;
+    ttl_seconds?: number;
+    problem_brief_id?: string;
+    evidence_pack_id?: string;
 }
 /**
- * 上传扫描数据到 stash，获取一次性 token（无需登录）
+ * 上传扫描数据到 scan-intake，获取一次性 token 与结构化问题对象（无需登录）
  */
 export declare function stashData(payload: AICOEVOPayload): Promise<StashResponse>;
 /**

--- a/dist/api/aicoevo-client.js
+++ b/dist/api/aicoevo-client.js
@@ -5,7 +5,7 @@
  * 基础URL: https://aicoevo.net (环境变量 AICO_EVO_URL 配置)
  *
  * 与 WinAICheck 对齐的流程:
- * 1. stash: POST /api/v1/stash → 获取 token（无需登录）
+ * 1. scan-intake: POST /api/v1/problem-briefs/scan-intake → 获取 token + problem brief（无需登录）
  * 2. claim: 浏览器打开 https://aicoevo.net/claim?t=TOKEN
  * 3. feedback: POST /api/v1/feedback（无需登录）
  */
@@ -143,7 +143,7 @@ function loadHistory(max = 10) {
     return out;
 }
 /**
- * 上传扫描数据到 stash，获取一次性 token（无需登录）
+ * 上传扫描数据到 scan-intake，获取一次性 token 与结构化问题对象（无需登录）
  */
 async function stashData(payload) {
     const fingerprint = JSON.stringify({
@@ -154,7 +154,7 @@ async function stashData(payload) {
         failCount: payload.results.filter(r => r.status === 'fail').length,
         failCategories: [...new Set(payload.results.filter(r => r.status === 'fail').map(r => r.category))],
     });
-    return apiFetch(`${getApiBase()}/stash`, {
+    return apiFetch(`${getApiBase()}/problem-briefs/scan-intake`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({

--- a/dist/index.js
+++ b/dist/index.js
@@ -326,8 +326,8 @@ async function runScan(serve) {
     try {
         (0, aicoevo_client_1.saveLocal)(payload);
         (0, aicoevo_client_1.stashData)(payload)
-            .then(({ token }) => {
-            const claimUrl = (0, aicoevo_client_1.buildClaimUrl)(token);
+            .then(({ token, claim_url }) => {
+            const claimUrl = claim_url || (0, aicoevo_client_1.buildClaimUrl)(token);
             console.log('\n[+] 扫描结果已上传，请在浏览器打开认领你的环境报告:');
             console.log(`    ${claimUrl}\n`);
         })

--- a/src/api/aicoevo-client.ts
+++ b/src/api/aicoevo-client.ts
@@ -4,7 +4,7 @@
  * 基础URL: https://aicoevo.net (环境变量 AICO_EVO_URL 配置)
  *
  * 与 WinAICheck 对齐的流程:
- * 1. stash: POST /api/v1/stash → 获取 token（无需登录）
+ * 1. scan-intake: POST /api/v1/problem-briefs/scan-intake → 获取 token + problem brief（无需登录）
  * 2. claim: 浏览器打开 https://aicoevo.net/claim?t=TOKEN
  * 3. feedback: POST /api/v1/feedback（无需登录）
  */
@@ -208,10 +208,14 @@ export interface StashRequest {
 
 export interface StashResponse {
   token: string;
+  claim_url?: string;
+  ttl_seconds?: number;
+  problem_brief_id?: string;
+  evidence_pack_id?: string;
 }
 
 /**
- * 上传扫描数据到 stash，获取一次性 token（无需登录）
+ * 上传扫描数据到 scan-intake，获取一次性 token 与结构化问题对象（无需登录）
  */
 export async function stashData(payload: AICOEVOPayload): Promise<StashResponse> {
   const fingerprint = JSON.stringify({
@@ -223,7 +227,7 @@ export async function stashData(payload: AICOEVOPayload): Promise<StashResponse>
     failCategories: [...new Set(payload.results.filter(r => r.status === 'fail').map(r => r.category))],
   });
 
-  return apiFetch<StashResponse>(`${getApiBase()}/stash`, {
+  return apiFetch<StashResponse>(`${getApiBase()}/problem-briefs/scan-intake`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({

--- a/src/index.ts
+++ b/src/index.ts
@@ -298,8 +298,8 @@ async function runScan(serve: boolean) {
   try {
     saveLocal(payload);
     stashData(payload)
-      .then(({ token }) => {
-        const claimUrl = buildClaimUrl(token);
+      .then(({ token, claim_url }) => {
+        const claimUrl = claim_url || buildClaimUrl(token);
         console.log('\n[+] 扫描结果已上传，请在浏览器打开认领你的环境报告:');
         console.log(`    ${claimUrl}\n`);
       })

--- a/tests/scan-intake.test.ts
+++ b/tests/scan-intake.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createPayload, stashData } from '../src/api/aicoevo-client';
+import type { ScanResult } from '../src/scanners/types';
+
+describe('scan intake upload contract', () => {
+  it('uploads scan payload to problem-brief scan-intake endpoint', async () => {
+    const results: ScanResult[] = [
+      {
+        id: 'openclaw',
+        name: 'OpenClaw',
+        category: 'ai-tools',
+        status: 'fail',
+        message: 'OpenClaw config missing',
+        error_type: 'misconfigured',
+      },
+    ];
+    const payload = createPayload(results, { score: 45 } as { score: number });
+
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        token: 'abc123',
+        claim_url: 'https://aicoevo.net/claim?t=abc123',
+        ttl_seconds: 900,
+        problem_brief_id: 'pb1',
+        evidence_pack_id: 'ep1',
+      }),
+    });
+
+    vi.stubGlobal('fetch', fetchMock);
+    try {
+      const result = await stashData(payload);
+      expect(result.problem_brief_id).toBe('pb1');
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      expect(fetchMock.mock.calls[0]?.[0]).toBe('https://aicoevo.net/api/v1/problem-briefs/scan-intake');
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- switch MacAICheck uploads from legacy `/api/v1/stash` to `/api/v1/problem-briefs/scan-intake`
- consume the richer response contract and prefer `claim_url` in CLI output while keeping `buildClaimUrl` as fallback
- add a focused contract test and refresh the committed runtime build artifacts used by the npm CLI package

## Validation
- `npm.cmd test -- tests/scan-intake.test.ts`
- `npm.cmd run build`
- `node dist/index.js --help`