### PR TITLE
Fix OpenClaw agent enable flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,24 @@ mac-aicheck/
 | `AICO_EVO_TOKEN` | — | 上报认证 Token |
 | `PORT` | `7890` | Web 服务端口 |
 
+### Agent Lite
+
+```bash
+# Claude Code + OpenClaw 一起启用
+mac-aicheck agent enable --target all
+
+# 仅启用 OpenClaw 监控
+mac-aicheck agent enable --target openclaw
+
+# 在 macOS 真机上跑 OpenClaw 烟雾验收
+bash scripts/openclaw-smoke.sh
+```
+
+说明：
+- Claude Code 使用 `~/.claude/settings.json` 的 SessionStart/PostToolUse hooks。
+- OpenClaw 使用 shell hook 写入 `~/.zshrc` / `~/.bashrc` / `~/.bash_profile`。
+- 悬赏命令需要先运行 `mac-aicheck agent bind` 获取 Agent API Key。
+
 ### 上报数据格式
 
 AICO EVO 使用与 WinAICheck 一致的格式：

--- a/scripts/openclaw-smoke.sh
+++ b/scripts/openclaw-smoke.sh
@@ -1,0 +1,97 @@
+#!/bin/bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TMP_DIR="$ROOT_DIR/.tmp"
+SCAN_JSON="$TMP_DIR/openclaw-smoke-scan.json"
+
+mkdir -p "$TMP_DIR"
+
+echo "[1/6] 环境检查"
+if [[ "$(uname -s)" != "Darwin" ]]; then
+  echo "此脚本只能在 macOS 上运行。" >&2
+  exit 1
+fi
+
+if ! command -v node >/dev/null 2>&1; then
+  echo "未找到 node，请先安装 Node.js。" >&2
+  exit 1
+fi
+
+if ! command -v openclaw >/dev/null 2>&1; then
+  echo "未找到 openclaw，请先执行: npm install -g openclaw" >&2
+  exit 1
+fi
+
+echo "  openclaw: $(openclaw --version)"
+echo "  node: $(node --version)"
+
+cd "$ROOT_DIR"
+
+echo "[2/6] 构建 MacAICheck"
+npm run build >/dev/null
+
+echo "[3/6] 真实扫描并上传"
+node - <<'NODE' > "$SCAN_JSON"
+const fs = require('node:fs');
+const path = require('node:path');
+const { scanAll, calculateScore } = require('./dist/scanners/index.js');
+const { createPayload, stashData } = require('./dist/api/aicoevo-client.js');
+
+(async () => {
+  const results = await scanAll();
+  const score = { score: calculateScore(results) };
+  const payload = createPayload(results, score);
+  let upload = null;
+  try {
+    upload = await stashData(payload);
+  } catch (error) {
+    upload = { error: error instanceof Error ? error.message : String(error) };
+  }
+  fs.writeFileSync(
+    path.join(process.cwd(), '.tmp', 'openclaw-smoke-scan.json'),
+    JSON.stringify({ score, results, upload }, null, 2) + '\n',
+    'utf-8',
+  );
+  process.stdout.write(JSON.stringify({ ok: true }, null, 2));
+})().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});
+NODE
+
+node - <<'NODE'
+const fs = require('node:fs');
+const report = JSON.parse(fs.readFileSync('.tmp/openclaw-smoke-scan.json', 'utf-8'));
+const byId = new Map(report.results.map((item) => [item.id, item]));
+for (const id of ['openclaw', 'openclaw-config-health', 'claude-code', 'claude-config-health']) {
+  const item = byId.get(id);
+  if (item) console.log(`  ${id}: ${item.status} - ${item.message}`);
+}
+if (report.upload?.claim_url) {
+  console.log(`  upload: ok - ${report.upload.claim_url}`);
+} else if (report.upload?.error) {
+  console.log(`  upload: warn - ${report.upload.error}`);
+}
+NODE
+
+echo "[4/6] 启用 OpenClaw Agent Hook"
+node dist/agent/index.js enable --target openclaw
+
+echo "[5/6] 验证 shell hook 与命令包装"
+if ! grep -q "function openclaw" "$HOME/.zshrc" 2>/dev/null && ! grep -q "function openclaw" "$HOME/.bashrc" 2>/dev/null; then
+  echo "未在 shell profile 中找到 openclaw hook。" >&2
+  exit 1
+fi
+zsh -lic 'whence -w openclaw; openclaw --version'
+
+echo "[6/6] 触发一次本地事件并尝试同步"
+node dist/agent/index.js capture --agent openclaw --message "OpenClaw smoke test: MCP config missing"
+if [[ -f "$HOME/.mac-aicheck/config.json" ]] && grep -q '"authToken"' "$HOME/.mac-aicheck/config.json"; then
+  node dist/agent/index.js sync || true
+else
+  echo "  未检测到 Agent API Key，跳过 sync。先运行: mac-aicheck agent bind --agent openclaw"
+fi
+
+echo
+echo "Smoke test 完成。详情见: $SCAN_JSON"

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -516,6 +516,26 @@ function stripHookBlock(text: string) {
   return r.trim() + '\n';
 }
 
+function targetIncludesClaude(target: string) {
+  return !target || target === 'all' || target === 'claude-code' || target === 'claude';
+}
+
+function targetIncludesOpenClaw(target: string) {
+  return !target || target === 'all' || target === 'openclaw' || target === 'open-claw';
+}
+
+function resolveProjectRootForHooks() {
+  const execPath = process.argv[1] || __filename;
+  const candidates = [
+    execPath.includes('/dist/') ? execPath.replace(/\/dist\/.*$/, '') : execPath.replace(/\/src\/.*$/, ''),
+    process.cwd(),
+  ];
+  for (const candidate of candidates) {
+    if (candidate && existsSync(join(candidate, 'hooks-src', 'session-start-hook.js'))) return candidate;
+  }
+  return process.cwd();
+}
+
 function installHook(args: Record<string, unknown>) {
   const p = paths();
   const target = String(args.target || 'all');
@@ -556,11 +576,8 @@ function installSettingsHook(): { hookType: 'settings'; hooks: string[] } {
   const hooksDir = join(getHome(), '.claude', 'hooks');
   ensureDir(hooksDir);
 
-  // Resolve hook source files from hooks-src/ directory
-  const execPath = process.argv[1] || __filename;
-  const projectRoot = execPath.includes('/dist/')
-    ? execPath.replace(/\/dist\/.*$/, '')  // e.g. /path/to/mac-aicheck
-    : execPath.replace(/\/src\/.*$/, ''); // same
+  // Resolve hook source files from hooks-src/ directory.
+  const projectRoot = resolveProjectRootForHooks();
 
   const sessionHookSrc = join(projectRoot, 'hooks-src', 'session-start-hook.js');
   const postToolHookSrc = join(projectRoot, 'hooks-src', 'post-tool-hook.js');
@@ -785,16 +802,16 @@ export async function main(argv: string[]) {
     process.stdout.write(`mac-aicheck Agent Lite
 
 用法:
-  mac-aicheck agent enable --target claude-code|all  一键启用监控（新方式，推荐）
+  mac-aicheck agent enable --target claude-code|openclaw|all  一键启用监控（新方式，推荐）
   mac-aicheck agent migrate                迁移到 SessionStart Hook（新方式，推荐）
-  mac-aicheck agent install-hook --target claude-code|all
+  mac-aicheck agent install-hook --target claude-code|openclaw|all
   mac-aicheck agent uninstall-hook --target all
   mac-aicheck agent capture --agent <name> --message <text>
   mac-aicheck agent sync
   mac-aicheck agent pause|resume
   mac-aicheck agent advice --format json|markdown
   mac-aicheck agent diagnose          分析失败模式，类比 Evolver 信号诊断
-  mac-aicheck agent bind [--agent claude-code]  绑定设备（自动打开浏览器确认）
+  mac-aicheck agent bind [--agent claude-code|openclaw]  绑定设备（自动打开浏览器确认）
   mac-aicheck agent review-list
   mac-aicheck agent review-submit <lease_id> --result success|partial|failed
   mac-aicheck agent install-local-agent
@@ -817,23 +834,33 @@ export async function main(argv: string[]) {
   if (command === 'install-hook') { const r = installHook(args); process.stdout.write(`已安装 Hook: ${r.agents.map((a: { target: string }) => a.target).join(', ')}\n`); return 0; }
   if (command === 'install-local-agent') { const r = installLocalAgent(); process.stdout.write(JSON.stringify({ ok: true, ...r }) + '\n'); return 0; }
   if (command === 'enable') {
-    // 一键安装：runner + SessionStart hook + 启用同步（新方式）
+    // 一键安装：runner + 针对目标 Agent 的 hook + 启用同步
+    const target = String(args.target || 'all');
     const r = installLocalAgent();
-    const hookResult = installSettingsHook();
+    const hookOutputs: string[] = [];
+    if (targetIncludesClaude(target)) {
+      const settingsHook = installSettingsHook();
+      hookOutputs.push(...settingsHook.hooks.map(h => `Claude Code settings: ${h}`));
+    }
+    if (targetIncludesOpenClaw(target)) {
+      const shellHook = installHook({ target: 'openclaw' });
+      hookOutputs.push(`OpenClaw shell: ${shellHook.agents.map((a: { target: string }) => a.target).join(', ')}`);
+    }
     const cfg = loadConfig();
     cfg.shareData = true;
     cfg.autoSync = true;
     cfg.paused = false;
     saveConfig(cfg);
-    process.stdout.write(`mac-aicheck Agent Lite 已启用 (SessionStart Hook 方式)\n`);
+    process.stdout.write(`mac-aicheck Agent Lite 已启用\n`);
     process.stdout.write(`  Agent Runner: ${r.agentJs}\n`);
-    process.stdout.write(`  Hook: ${hookResult.hooks.join(', ')}\n`);
+    if (hookOutputs.length > 0) process.stdout.write(`  Hook: ${hookOutputs.join('; ')}\n`);
     process.stdout.write(`  自动同步: 已启用\n`);
 
     // Auto-detect installed agents and bind (#30)
     if (!cfg.authToken) {
       const agents: Array<{ name: string; cmd: string; agentType: string }> = [];
       for (const { name, cmd, agentType } of [{ name: 'Claude Code', cmd: 'claude', agentType: 'claude-code' }, { name: 'OpenClaw', cmd: 'openclaw', agentType: 'openclaw' }]) {
+        if ((agentType === 'claude-code' && !targetIncludesClaude(target)) || (agentType === 'openclaw' && !targetIncludesOpenClaw(target))) continue;
         try {
           execFileSync('command', ['-v', cmd], { encoding: 'utf-8', timeout: 3000, stdio: 'pipe' });
           agents.push({ name, cmd, agentType });

--- a/src/agent/local-state.ts
+++ b/src/agent/local-state.ts
@@ -153,7 +153,7 @@ export function enableAgentExperience(target = 'all'): { ok: boolean; localAgent
   let hookOutput = '';
   let hookOk = false;
   try {
-    hookOutput = runAgentCommand(['install-hook', '--target', target]);
+    hookOutput = runAgentCommand(['enable', '--target', target]);
     hookOk = true;
   } catch {
     hookOk = false;

--- a/src/index.ts
+++ b/src/index.ts
@@ -332,7 +332,7 @@ if (args.includes('--serve') || args.includes('--web')) {
 } else if (args.includes('--json')) {
   runScan(false).then(r => { if (r) console.log(JSON.stringify(r, null, 2)); }).catch(console.error);
 } else if (args.includes('--help') || args.length === 0) {
-  console.log('MacAICheck - AI Dev Environment Checker\nUsage:\n  mac-aicheck          Run diagnosis\n  mac-aicheck --serve   Start Web UI\n  mac-aicheck --json    JSON output\n  mac-aicheck agent     Agent Lite commands (install-hook, sync, etc.)');
+  console.log('MacAICheck - AI Dev Environment Checker\nUsage:\n  mac-aicheck          Run diagnosis\n  mac-aicheck --serve   Start Web UI\n  mac-aicheck --json    JSON output\n  mac-aicheck agent     Agent Lite commands (enable/install-hook/sync, etc.)');
 } else if (args.includes('agent')) {
   // Agent Lite CLI 子命令
   const agentArgs = args.slice(args.indexOf('agent') + 1);

--- a/tests/agent-enable.test.ts
+++ b/tests/agent-enable.test.ts
@@ -1,0 +1,98 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import path from 'node:path';
+import { tmpdir } from 'node:os';
+
+function createTempHome() {
+  return mkdtempSync(path.join(tmpdir(), 'mac-aicheck-enable-'));
+}
+
+describe('agent enable targets', () => {
+  const homes: string[] = [];
+  const originalHome = process.env.HOME;
+  const originalArgv1 = process.argv[1];
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.resetModules();
+    vi.unstubAllGlobals();
+    process.env.HOME = originalHome;
+    process.argv[1] = originalArgv1;
+    for (const home of homes.splice(0)) {
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  async function loadAgentMain(execImpl?: (cmd: string, args?: string[]) => string) {
+    vi.doMock('child_process', () => ({
+      execFileSync: vi.fn((cmd: string, args?: string[]) => {
+        if (execImpl) return execImpl(cmd, args);
+        if (cmd === 'command' && args?.[0] === '-v' && args[1] === 'claude') return '/usr/local/bin/claude\n';
+        if (cmd === 'command' && args?.[0] === '-v' && args[1] === 'openclaw') return '/usr/local/bin/openclaw\n';
+        return '';
+      }),
+      spawn: vi.fn(),
+    }));
+    const mod = await import('../src/agent/index');
+    return mod.main;
+  }
+
+  it('enable --target all installs Claude settings hook and OpenClaw shell hook', async () => {
+    const home = createTempHome();
+    homes.push(home);
+    process.env.HOME = home;
+    process.argv[1] = path.join(process.cwd(), 'src', 'agent', 'index.ts');
+
+    const fetchMock = vi.fn().mockResolvedValue({
+      status: 200,
+      ok: true,
+      json: async () => ({ confirm_url: 'https://aicoevo.net/bind/test' }),
+      text: async () => JSON.stringify({ confirm_url: 'https://aicoevo.net/bind/test' }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const stdout = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    const main = await loadAgentMain();
+    const code = await main(['enable', '--target', 'all']);
+    stdout.mockRestore();
+
+    expect(code).toBe(0);
+    expect(readFileSync(path.join(home, '.claude', 'settings.json'), 'utf-8')).toContain('mac-aicheck-post-tool.js');
+    const zshrc = readFileSync(path.join(home, '.zshrc'), 'utf-8');
+    expect(zshrc).toContain('function openclaw');
+    expect(zshrc).not.toContain('function claude');
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock.mock.calls[0]?.[0]).toContain('agent_type=claude-code');
+    expect(fetchMock.mock.calls[1]?.[0]).toContain('agent_type=openclaw');
+  });
+
+  it('enable --target openclaw only installs OpenClaw shell hook', async () => {
+    const home = createTempHome();
+    homes.push(home);
+    process.env.HOME = home;
+    process.argv[1] = path.join(process.cwd(), 'src', 'agent', 'index.ts');
+
+    const fetchMock = vi.fn().mockResolvedValue({
+      status: 200,
+      ok: true,
+      json: async () => ({ confirm_url: 'https://aicoevo.net/bind/openclaw' }),
+      text: async () => JSON.stringify({ confirm_url: 'https://aicoevo.net/bind/openclaw' }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const main = await loadAgentMain((cmd, args) => {
+      if (cmd === 'command' && args?.[0] === '-v' && args[1] === 'openclaw') return '/usr/local/bin/openclaw\n';
+      if (cmd === 'command' && args?.[0] === '-v' && args[1] === 'claude') throw new Error('not found');
+      return '';
+    });
+
+    const code = await main(['enable', '--target', 'openclaw']);
+    expect(code).toBe(0);
+    expect(existsSync(path.join(home, '.claude', 'settings.json'))).toBe(false);
+    const zshrc = readFileSync(path.join(home, '.zshrc'), 'utf-8');
+    expect(zshrc).toContain('function openclaw');
+    expect(zshrc).not.toContain('function claude');
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock.mock.calls[0]?.[0]).toContain('agent_type=openclaw');
+  });
+});


### PR DESCRIPTION
## Summary
- make `mac-aicheck agent enable --target openclaw|all` install the actual OpenClaw shell hook instead of only Claude settings hooks
- route local Web UI enable flow through the full `enable` command and expand CLI/help docs for OpenClaw targets
- add regression coverage for target-specific enable behavior and a macOS OpenClaw smoke-test script for real-device validation

## Testing
- npm run build
- npx vitest run tests/agent-enable.test.ts tests/agent-v2-flow.test.ts tests/scan-intake.test.ts tests/aicoevo-contract.test.ts

## Follow-up
- Real macOS validation is being coordinated in #53
