### PR TITLE
feat: owner-check and owner-verify commands (TASK-100)

### DIFF
--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -486,6 +486,87 @@ function writeAdvice(advice: Record<string, unknown>) {
   writeFileSync(p.adviceMd, lines.join('\n') + '\n', 'utf-8');
 }
 
+function ownerVerifyFiles(bountyId: string, answerId: string) {
+  const p = paths();
+  const slug = [bountyId || 'unknown', answerId || 'unknown']
+    .map(value => String(value || '').replace(/[^a-zA-Z0-9_-]+/g, '-'))
+    .join('__');
+  const dir = join(p.base, 'owner-verify');
+  return {
+    dir,
+    guideMd: join(dir, `${slug}.md`),
+    snapshotJson: join(dir, `${slug}.json`),
+  };
+}
+
+function ownerVerifyLocalContext(config: Record<string, unknown>) {
+  return {
+    clientId: String(config.clientId || ''),
+    deviceId: String(config.deviceId || ''),
+    autoSync: config.autoSync !== false,
+    paused: Boolean(config.paused),
+    shareData: config.shareData !== false,
+    host: hostname(),
+    platform: process.platform,
+    nodeVersion: process.version,
+  };
+}
+
+function writeOwnerVerifyGuide(item: Record<string, string>, config: Record<string, unknown>) {
+  const files = ownerVerifyFiles(String(item.bounty_id || ''), String(item.answer_id || ''));
+  const generatedAt = nowIso();
+  const localContext = ownerVerifyLocalContext(config);
+  const verifyCommand = `mac-aicheck agent owner-verify ${item.bounty_id} --answer ${item.answer_id} --result success|partial|failed --cmd "<local validation command>"`;
+  const lines = [
+    '# AICOEVO 发起者复现指南',
+    '',
+    `- Bounty: ${item.bounty_id}`,
+    `- Answer: ${item.answer_id}`,
+    `- 标题: ${item.title || '(无标题)'}`,
+    `- 提交时间: ${item.submitted_at || '-'}`,
+    `- 截止时间: ${item.deadline_at || '-'}`,
+    '',
+    '## 方案摘要',
+    '',
+    item.solution_summary || '暂无方案摘要。',
+    '',
+    '## 建议操作',
+    '',
+    '1. 在你自己的本地环境里手动复现原问题。',
+    '2. 按方案摘要执行修复或验证命令，确认现象是否消失。',
+    '3. 记录你实际执行过的命令和结果，再提交 owner-verify。',
+    '',
+    '## 提交命令',
+    '',
+    `\`${verifyCommand}\``,
+    '',
+    '默认策略为 prompt：命令会再次要求你确认，不会静默替你提交。',
+    '',
+  ];
+  ensureDir(files.dir);
+  writeFileSync(files.guideMd, lines.join('\n') + '\n', 'utf-8');
+  const snapshot = {
+    schemaVersion: 1,
+    generatedAt,
+    item,
+    localContext,
+    verifyCommand,
+  };
+  writeJson(files.snapshotJson, snapshot);
+  return {
+    ...files,
+    guideSha256: sha256(readFileSync(files.guideMd, 'utf-8')),
+    snapshot,
+  };
+}
+
+function loadOwnerVerifySnapshot(bountyId: string, answerId: string) {
+  const files = ownerVerifyFiles(bountyId, answerId);
+  const snapshot = readJson<Record<string, unknown> | null>(files.snapshotJson, null);
+  const guideSha256 = existsSync(files.guideMd) ? sha256(readFileSync(files.guideMd, 'utf-8')) : '';
+  return { ...files, guideSha256, snapshot };
+}
+
 function resolveCommand(cmd: string) { try { return execFileSync('command', ['-v', cmd], { encoding: 'utf-8', stdio: ['ignore', 'pipe', 'ignore'] }).split('\n').filter(Boolean)[0] || cmd; } catch { return cmd; } }
 function defaultProfilePaths() { const h = getHome(); return [join(h, '.zshrc'), join(h, '.bashrc'), join(h, '.bash_profile')]; }
 
@@ -1387,12 +1468,15 @@ export async function main(argv: string[]) {
       }
       process.stdout.write(`待复现确认 (${pending.length}):\n\n`);
       for (const item of pending) {
+        const guide = writeOwnerVerifyGuide(item, cfg);
         process.stdout.write(`## ${item.title || '(无标题)'}\n`);
         process.stdout.write(`  Bounty:   ${item.bounty_id}\n`);
         process.stdout.write(`  Answer:   ${item.answer_id}\n`);
         process.stdout.write(`  方案摘要: ${item.solution_summary}\n`);
         process.stdout.write(`  提交时间: ${item.submitted_at}\n`);
         process.stdout.write(`  截止时间: ${item.deadline_at}\n\n`);
+        process.stdout.write(`  指南:     ${guide.guideMd}\n`);
+        process.stdout.write(`  快照:     ${guide.snapshotJson}\n\n`);
         process.stdout.write(`  → mac-aicheck agent owner-verify ${item.bounty_id} --answer ${item.answer_id} --result success|partial|failed\n\n`);
       }
     } catch (e: unknown) { process.stdout.write(`获取待复现列表失败: ${(e as Error).message}\n`); return 1; }
@@ -1413,6 +1497,18 @@ export async function main(argv: string[]) {
     }
     const notes = String(args.notes || '');
     const commandsRun = args.cmd ? String(args.cmd).split(',').map((s: string) => s.trim()).filter(Boolean) : [];
+    const fallbackItem = {
+      bounty_id: bountyId,
+      answer_id: answerId,
+      title: '待确认方案',
+      solution_summary: notes || '请在本地环境确认问题是否已消失。',
+      submitted_at: '',
+      deadline_at: '',
+    };
+    let guideRecord = loadOwnerVerifySnapshot(bountyId, answerId);
+    if (!guideRecord.snapshot) {
+      guideRecord = writeOwnerVerifyGuide(fallbackItem, cfg);
+    }
 
     // prompt 策略: 默认必须提示用户确认
     const skipPrompt = args.yes === true || args.yes === 'true';
@@ -1432,6 +1528,15 @@ export async function main(argv: string[]) {
     }
 
     try {
+      const submittedAt = nowIso();
+      const afterContext = {
+        submitted_at: submittedAt,
+        confirmation_mode: skipPrompt ? 'flag_yes' : 'interactive_prompt',
+        result: resultValue,
+        notes,
+        commands_run: commandsRun,
+        local_context: ownerVerifyLocalContext(cfg),
+      };
       const result = await requestJson(`${agentApiBase('v2')}/bounties/${bountyId}/owner-verify`, {
         method: 'POST',
         headers,
@@ -1440,8 +1545,31 @@ export async function main(argv: string[]) {
           result: resultValue,
           notes,
           commands_run: commandsRun,
-          proof_payload: {},
-          artifacts: {},
+          proof_payload: {
+            summary: `Owner verification for ${bountyId}/${answerId}`,
+            steps: [
+              `读取本地指南: ${guideRecord.guideMd}`,
+              commandsRun.length
+                ? `本地执行验证命令: ${commandsRun.join(' ; ')}`
+                : '按本地指南手动确认问题是否消失。',
+              `用户确认结果: ${resultValue}`,
+            ],
+            before_context: guideRecord.snapshot || {},
+            after_context: afterContext,
+            validation_cmd: commandsRun[0] || '',
+            expected_output:
+              resultValue === 'success'
+                ? '问题已消失或行为符合预期'
+                : resultValue === 'partial'
+                  ? '问题部分缓解，但仍有残留'
+                  : '问题仍然可复现',
+          },
+          artifacts: {
+            owner_reproduction_guide_path: guideRecord.guideMd,
+            owner_reproduction_snapshot_path: guideRecord.snapshotJson,
+            owner_reproduction_guide_sha256: guideRecord.guideSha256,
+            owner_reproduction_snapshot_generated_at: (guideRecord.snapshot as Record<string, unknown> | null)?.generatedAt || '',
+          },
         },
       });
       if (result.status !== 200) {

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -814,6 +814,9 @@ export async function main(argv: string[]) {
   mac-aicheck agent bind [--agent claude-code|openclaw]  绑定设备（自动打开浏览器确认）
   mac-aicheck agent review-list
   mac-aicheck agent review-submit <lease_id> --result success|partial|failed
+  mac-aicheck agent owner-check                            查看待复现确认的方案列表
+  mac-aicheck agent owner-verify <bounty_id> --answer <id> --result success|partial|failed
+                                                           提交复现验证结果
   mac-aicheck agent install-local-agent
   mac-aicheck agent upgrade            一键更新 claude-code / openclaw 到最新版本
   mac-aicheck agent upgrade self       更新 mac-aicheck 自身到最新版本
@@ -1365,6 +1368,93 @@ export async function main(argv: string[]) {
       if (result.status >= 400) { process.stdout.write(`提交评审失败: ${JSON.stringify(result.data)}\n`); return 1; }
       process.stdout.write(`✓ 评审已提交 ${leaseId}\n`);
     } catch (e: unknown) { process.stdout.write(`提交评审失败: ${(e as Error).message}\n`); return 1; }
+    return 0;
+  }
+
+  // ── TASK-100: 发起者复现循环 ──
+
+  if (command === 'owner-check') {
+    const cfg = loadConfig();
+    const headers = agentApiKeyHeaders(cfg);
+    if (!headers) { process.stdout.write('需要 Agent API Key，请先运行 mac-aicheck agent bind\n'); return 1; }
+    try {
+      const result = await requestJson(`${agentApiBase('v2')}/status`, { headers });
+      if (result.status !== 200) { process.stdout.write(`获取状态失败: ${result.status}\n`); return 1; }
+      const pending = (result.data as Record<string, unknown>).pending_owner_verifications as Array<Record<string, string>> || [];
+      if (pending.length === 0) {
+        process.stdout.write('没有待复现确认的方案。\n');
+        return 0;
+      }
+      process.stdout.write(`待复现确认 (${pending.length}):\n\n`);
+      for (const item of pending) {
+        process.stdout.write(`## ${item.title || '(无标题)'}\n`);
+        process.stdout.write(`  Bounty:   ${item.bounty_id}\n`);
+        process.stdout.write(`  Answer:   ${item.answer_id}\n`);
+        process.stdout.write(`  方案摘要: ${item.solution_summary}\n`);
+        process.stdout.write(`  提交时间: ${item.submitted_at}\n`);
+        process.stdout.write(`  截止时间: ${item.deadline_at}\n\n`);
+        process.stdout.write(`  → mac-aicheck agent owner-verify ${item.bounty_id} --answer ${item.answer_id} --result success|partial|failed\n\n`);
+      }
+    } catch (e: unknown) { process.stdout.write(`获取待复现列表失败: ${(e as Error).message}\n`); return 1; }
+    return 0;
+  }
+
+  if (command === 'owner-verify') {
+    const cfg = loadConfig();
+    const headers = agentApiKeyHeaders(cfg);
+    if (!headers) { process.stdout.write('需要 Agent API Key，请先运行 mac-aicheck agent bind\n'); return 1; }
+    const bountyId = (args._ as string[])[0];
+    const answerId = String(args.answer || '');
+    const resultValue = String(args.result || '');
+    if (!bountyId || !answerId || !/^(success|partial|failed)$/.test(resultValue)) {
+      process.stdout.write('用法: mac-aicheck agent owner-verify <bounty_id> --answer <id> --result success|partial|failed\n');
+      process.stdout.write('       [--notes <text>] [--cmd <cmd1,cmd2>]\n');
+      return 1;
+    }
+    const notes = String(args.notes || '');
+    const commandsRun = args.cmd ? String(args.cmd).split(',').map((s: string) => s.trim()).filter(Boolean) : [];
+
+    // prompt 策略: 默认必须提示用户确认
+    const skipPrompt = args.yes === true || args.yes === 'true';
+    if (!skipPrompt) {
+      process.stdout.write(`\n即将提交复现验证:\n`);
+      process.stdout.write(`  Bounty: ${bountyId}\n`);
+      process.stdout.write(`  Answer: ${answerId}\n`);
+      process.stdout.write(`  Result: ${resultValue}\n`);
+      process.stdout.write(`\n请确认您已在本地环境验证该方案。输入 yes 继续: `);
+      const readline = await import('readline');
+      const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+      const confirm = await new Promise<string>(resolve => rl.question('', (ans: string) => { rl.close(); resolve(ans.trim().toLowerCase()); }));
+      if (confirm !== 'yes' && confirm !== 'y') {
+        process.stdout.write('已取消。\n');
+        return 0;
+      }
+    }
+
+    try {
+      const result = await requestJson(`${agentApiBase('v2')}/bounties/${bountyId}/owner-verify`, {
+        method: 'POST',
+        headers,
+        body: {
+          answer_id: answerId,
+          result: resultValue,
+          notes,
+          commands_run: commandsRun,
+          proof_payload: {},
+          artifacts: {},
+        },
+      });
+      if (result.status !== 200) {
+        process.stdout.write(`提交失败 (${result.status}): ${JSON.stringify(result.data)}\n`);
+        return 1;
+      }
+      const data = result.data as Record<string, unknown>;
+      process.stdout.write(`复现验证已提交:\n`);
+      process.stdout.write(`  状态: ${data.review_status || 'unknown'}\n`);
+      process.stdout.write(`  Owner 分数: ${data.owner_score ?? '-'}\n`);
+      process.stdout.write(`  社区分数: ${data.community_score ?? '-'}\n`);
+      process.stdout.write(`  总分: ${data.total_score ?? '-'} / ${data.threshold ?? 70}\n`);
+    } catch (e: unknown) { process.stdout.write(`提交复现验证失败: ${(e as Error).message}\n`); return 1; }
     return 0;
   }
 

--- a/tests/agent-v2-flow.test.ts
+++ b/tests/agent-v2-flow.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { existsSync, mkdtempSync, mkdirSync, readFileSync, writeFileSync, rmSync } from 'node:fs';
 import path from 'node:path';
 import { tmpdir } from 'node:os';
 import { main as agentMain } from '../src/agent/index';
@@ -37,6 +37,7 @@ describe('agent v2 flow', () => {
     }), 'utf8');
     process.env.HOME = home;
     process.env.AICOEVO_BASE_URL = 'https://aicoevo.net';
+    return home;
   }
 
   it('reads recommended bounties from the v2 heartbeat response', async () => {
@@ -102,7 +103,7 @@ describe('agent v2 flow', () => {
   // ── TASK-100: Owner reproduction loop ──
 
   it('owner-check lists pending owner verifications from status', async () => {
-    seedConfig();
+    const home = seedConfig();
     const fetchMock = vi.fn().mockResolvedValue({
       status: 200,
       ok: true,
@@ -134,6 +135,11 @@ describe('agent v2 flow', () => {
     expect(output).toContain('a_001');
     expect(output).toContain('npm install fails');
     expect(output).toContain('owner-verify');
+    const guidePath = path.join(home, '.mac-aicheck', 'owner-verify', 'b_001__a_001.md');
+    const snapshotPath = path.join(home, '.mac-aicheck', 'owner-verify', 'b_001__a_001.json');
+    expect(existsSync(guidePath)).toBe(true);
+    expect(existsSync(snapshotPath)).toBe(true);
+    expect(readFileSync(guidePath, 'utf8')).toContain('AICOEVO 发起者复现指南');
   });
 
   it('owner-check shows empty message when no pending', async () => {
@@ -191,6 +197,11 @@ describe('agent v2 flow', () => {
     const body = JSON.parse(request?.body || '{}');
     expect(body.answer_id).toBe('a_001');
     expect(body.result).toBe('success');
+    expect(body.proof_payload.summary).toContain('b_001/a_001');
+    expect(body.proof_payload.before_context.item.answer_id).toBe('a_001');
+    expect(body.proof_payload.after_context.result).toBe('success');
+    expect(body.artifacts.owner_reproduction_guide_path).toContain('b_001__a_001.md');
+    expect(body.artifacts.owner_reproduction_snapshot_path).toContain('b_001__a_001.json');
     expect(output).toContain('60');
     expect(output).toContain('pending_review');
   });

--- a/tests/agent-v2-flow.test.ts
+++ b/tests/agent-v2-flow.test.ts
@@ -98,4 +98,117 @@ describe('agent v2 flow', () => {
     expect(calls[1]?.body).toBe('{}');
     expect(output).toContain('lease_1');
   });
+
+  // ── TASK-100: Owner reproduction loop ──
+
+  it('owner-check lists pending owner verifications from status', async () => {
+    seedConfig();
+    const fetchMock = vi.fn().mockResolvedValue({
+      status: 200,
+      ok: true,
+      text: async () => JSON.stringify({
+        owner_metrics: { queued_problems: 0, solutions_pending_owner: 1 },
+        worker_metrics: {},
+        pending_owner_verifications: [{
+          bounty_id: 'b_001',
+          answer_id: 'a_001',
+          title: 'npm install fails',
+          solution_summary: 'Run npm cache clean --force',
+          submitted_at: '2026-04-26T00:00:00Z',
+          deadline_at: '2026-04-28T00:00:00Z',
+        }],
+        timestamp: '2026-04-26T00:00:00Z',
+      }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const stdout = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    const code = await agentMain(['owner-check']);
+    const output = stdout.mock.calls.map(call => String(call[0])).join('');
+    stdout.mockRestore();
+
+    expect(code).toBe(0);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock.mock.calls[0]?.[0]).toBe('https://aicoevo.net/api/v2/agent/status');
+    expect(output).toContain('b_001');
+    expect(output).toContain('a_001');
+    expect(output).toContain('npm install fails');
+    expect(output).toContain('owner-verify');
+  });
+
+  it('owner-check shows empty message when no pending', async () => {
+    seedConfig();
+    const fetchMock = vi.fn().mockResolvedValue({
+      status: 200,
+      ok: true,
+      text: async () => JSON.stringify({
+        owner_metrics: {},
+        worker_metrics: {},
+        pending_owner_verifications: [],
+        timestamp: '2026-04-26T00:00:00Z',
+      }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const stdout = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    const code = await agentMain(['owner-check']);
+    const output = stdout.mock.calls.map(call => String(call[0])).join('');
+    stdout.mockRestore();
+
+    expect(code).toBe(0);
+    expect(output).toContain('没有待复现确认');
+  });
+
+  it('owner-verify submits verification result to endpoint', async () => {
+    seedConfig();
+    let request: { url: string; body?: string } | null = null;
+    const fetchMock = vi.fn().mockImplementation(async (url: string, init?: RequestInit) => {
+      request = { url, body: init?.body ? String(init.body) : undefined };
+      return {
+        status: 200,
+        ok: true,
+        text: async () => JSON.stringify({
+          bounty_id: 'b_001',
+          answer_id: 'a_001',
+          owner_verification: 'success',
+          owner_score: 60,
+          community_score: 0,
+          total_score: 60,
+          threshold: 70,
+          review_status: 'pending_review',
+        }),
+      };
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const stdout = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    const code = await agentMain(['owner-verify', 'b_001', '--answer', 'a_001', '--result', 'success', '--yes']);
+    const output = stdout.mock.calls.map(call => String(call[0])).join('');
+    stdout.mockRestore();
+
+    expect(code).toBe(0);
+    expect(request?.url).toBe('https://aicoevo.net/api/v2/agent/bounties/b_001/owner-verify');
+    const body = JSON.parse(request?.body || '{}');
+    expect(body.answer_id).toBe('a_001');
+    expect(body.result).toBe('success');
+    expect(output).toContain('60');
+    expect(output).toContain('pending_review');
+  });
+
+  it('owner-verify rejects missing required args', async () => {
+    seedConfig();
+    const fetchMock = vi.fn().mockResolvedValue({
+      status: 200,
+      text: async () => '{}',
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const stdout = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    const code = await agentMain(['owner-verify']);
+    const output = stdout.mock.calls.map(call => String(call[0])).join('');
+    stdout.mockRestore();
+
+    expect(code).toBe(1);
+    expect(output).toContain('用法');
+  });
 });


### PR DESCRIPTION
## Summary
- Add `owner-check` command: lists pending owner verifications from `/api/v2/agent/status`
- Add `owner-verify` command: submits reproduction verification to `/api/v2/agent/bounties/{id}/owner-verify`
- Prompt-first strategy: requires explicit user confirmation (pass `--yes` to skip)

## Test plan
- [x] 6 tests passed (2 existing + 4 new for owner-check/owner-verify)
- [x] npm test -- agent-v2-flow.test.ts passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)