### PR TITLE
fix(scan): reduce false positives and align repair flow

### DIFF
--- a/src/cli/options.ts
+++ b/src/cli/options.ts
@@ -1,0 +1,3 @@
+export function shouldUploadScan(args: string[]): boolean {
+  return args.includes('--upload') || args.includes('upload');
+}

--- a/src/fixers/ai-tools.ts
+++ b/src/fixers/ai-tools.ts
@@ -1,0 +1,93 @@
+import type { Fixer, FixResult, PostFixGuidance } from './types';
+import type { ScanResult } from '../scanners/types';
+import { registerFixer } from './registry';
+import { getInstallerById } from '../installers/index';
+
+interface InstallerBackedFixerConfig {
+  fixerId: string;
+  scannerId: string;
+  name: string;
+  verifyCommand: string;
+  notes?: string[];
+}
+
+function createInstallerBackedFixer(config: InstallerBackedFixerConfig): Fixer {
+  return {
+    id: config.fixerId,
+    name: config.name,
+    risk: 'green',
+    scannerIds: [config.scannerId],
+
+    canFix(scanResult: ScanResult): boolean {
+      return scanResult.id === config.scannerId && (scanResult.status === 'warn' || scanResult.status === 'fail');
+    },
+
+    async execute(_scanResult: ScanResult, dryRun?: boolean): Promise<FixResult> {
+      if (dryRun) {
+        return {
+          success: true,
+          message: `[dry-run] 将执行 ${config.name} 安装`,
+          verified: false,
+        };
+      }
+
+      const installer = getInstallerById(config.scannerId);
+      if (!installer) {
+        return {
+          success: false,
+          message: `未找到 ${config.name} 安装器`,
+          verified: false,
+        };
+      }
+
+      const result = await installer.run(() => {});
+      return {
+        success: result.success,
+        message: result.message,
+        verified: false,
+      };
+    },
+
+    getGuidance(): PostFixGuidance {
+      return {
+        needsTerminalRestart: true,
+        needsReboot: false,
+        verifyCommands: [config.verifyCommand],
+        notes: config.notes,
+      };
+    },
+
+    getVerificationCommand(): string | string[] {
+      return config.verifyCommand;
+    },
+  };
+}
+
+[
+  createInstallerBackedFixer({
+    fixerId: 'claude-code-fixer',
+    scannerId: 'claude-code',
+    name: 'Claude Code 安装',
+    verifyCommand: 'claude --version',
+    notes: ['首次运行 claude 需要登录 Anthropic 账号或配置 API Key'],
+  }),
+  createInstallerBackedFixer({
+    fixerId: 'openclaw-fixer',
+    scannerId: 'openclaw',
+    name: 'OpenClaw 安装',
+    verifyCommand: 'openclaw --version',
+  }),
+  createInstallerBackedFixer({
+    fixerId: 'gemini-cli-fixer',
+    scannerId: 'gemini-cli',
+    name: 'Gemini CLI 安装',
+    verifyCommand: 'gemini --version',
+  }),
+  createInstallerBackedFixer({
+    fixerId: 'ccswitch-fixer',
+    scannerId: 'ccswitch',
+    name: 'CCSwitch 安装',
+    verifyCommand: 'ccswitch --version',
+    notes: ['如果 npm 安装失败，安装器会尝试使用 GitHub 下载备用方案'],
+  }),
+].forEach(registerFixer);

--- a/src/fixers/git-identity.ts
+++ b/src/fixers/git-identity.ts
@@ -42,6 +42,11 @@ function resolveGitIdentity(): { name: string | null; email: string | null } {
   return { name, email };
 }
 
+function canAutoConfigureGitIdentity(): boolean {
+  const { name, email } = resolveGitIdentity();
+  return commandExists('git') && Boolean(name && email);
+}
+
 const gitIdentityFixer: Fixer = {
   id: 'git-identity-fixer',
   name: 'Git 身份配置',
@@ -49,7 +54,9 @@ const gitIdentityFixer: Fixer = {
   scannerIds: ['git-identity'],
 
   canFix(scanResult: ScanResult): boolean {
-    return scanResult.id === 'git-identity' && scanResult.status === 'warn';
+    return scanResult.id === 'git-identity'
+      && scanResult.status === 'warn'
+      && canAutoConfigureGitIdentity();
   },
 
   async execute(_scanResult: ScanResult, dryRun?: boolean): Promise<FixResult> {

--- a/src/fixers/git-identity.ts
+++ b/src/fixers/git-identity.ts
@@ -1,0 +1,138 @@
+import type { Fixer, FixResult, PostFixGuidance } from './types';
+import type { ScanResult } from '../scanners/types';
+import { registerFixer } from './registry';
+import { commandExists, runCommand } from '../executor/index';
+
+function escapeShellArg(value: string): string {
+  return `'${value.replace(/'/g, `'\"'\"'`)}'`;
+}
+
+function firstNonEmpty(values: Array<string | undefined | null>): string | null {
+  for (const value of values) {
+    const trimmed = String(value || '').trim();
+    if (trimmed) return trimmed;
+  }
+  return null;
+}
+
+function readGitConfig(key: 'user.name' | 'user.email'): string | null {
+  return firstNonEmpty([
+    runCommand(`git config --global ${key} 2>/dev/null || echo ""`, 3000).stdout,
+  ]);
+}
+
+function resolveGitIdentity(): { name: string | null; email: string | null } {
+  const name = firstNonEmpty([
+    process.env.MAC_AICHECK_GIT_NAME,
+    process.env.GIT_AUTHOR_NAME,
+    process.env.GIT_COMMITTER_NAME,
+    readGitConfig('user.name'),
+    runCommand('id -F 2>/dev/null || echo ""', 3000).stdout,
+    runCommand('whoami 2>/dev/null || echo ""', 3000).stdout,
+  ]);
+
+  const email = firstNonEmpty([
+    process.env.MAC_AICHECK_GIT_EMAIL,
+    process.env.GIT_AUTHOR_EMAIL,
+    process.env.GIT_COMMITTER_EMAIL,
+    process.env.EMAIL,
+    readGitConfig('user.email'),
+  ]);
+
+  return { name, email };
+}
+
+const gitIdentityFixer: Fixer = {
+  id: 'git-identity-fixer',
+  name: 'Git 身份配置',
+  risk: 'yellow',
+  scannerIds: ['git-identity'],
+
+  canFix(scanResult: ScanResult): boolean {
+    return scanResult.id === 'git-identity' && scanResult.status === 'warn';
+  },
+
+  async execute(_scanResult: ScanResult, dryRun?: boolean): Promise<FixResult> {
+    const { name, email } = resolveGitIdentity();
+
+    if (dryRun) {
+      return {
+        success: Boolean(name && email),
+        message: name && email
+          ? `[dry-run] 将配置 Git 身份: ${name} <${email}>`
+          : '[dry-run] 需要提供 Git name/email 后才能自动配置',
+        verified: false,
+        nextSteps: name && email ? undefined : [
+          '设置环境变量 MAC_AICHECK_GIT_NAME 和 MAC_AICHECK_GIT_EMAIL 后重试',
+          '或手动运行: git config --global user.name "Your Name"',
+          '或手动运行: git config --global user.email "you@example.com"',
+        ],
+      };
+    }
+
+    if (!commandExists('git')) {
+      return {
+        success: false,
+        message: 'Git 未安装，请先安装 Git',
+        verified: false,
+      };
+    }
+
+    if (!name || !email) {
+      return {
+        success: false,
+        message: '缺少可用的 Git 用户名或邮箱，无法安全自动配置',
+        verified: false,
+        nextSteps: [
+          '先设置环境变量 MAC_AICHECK_GIT_NAME 和 MAC_AICHECK_GIT_EMAIL 后重试',
+          '或手动运行: git config --global user.name "Your Name"',
+          '手动运行: git config --global user.email "you@example.com"',
+        ],
+      };
+    }
+
+    const setName = runCommand(`git config --global user.name ${escapeShellArg(name)}`, 5000);
+    if (setName.exitCode !== 0) {
+      return {
+        success: false,
+        message: `Git user.name 配置失败: ${setName.stderr || setName.stdout || 'unknown error'}`,
+        verified: false,
+      };
+    }
+
+    const setEmail = runCommand(`git config --global user.email ${escapeShellArg(email)}`, 5000);
+    if (setEmail.exitCode !== 0) {
+      return {
+        success: false,
+        message: `Git user.email 配置失败: ${setEmail.stderr || setEmail.stdout || 'unknown error'}`,
+        verified: false,
+      };
+    }
+
+    return {
+      success: true,
+      message: `Git 身份已配置为 ${name} <${email}>`,
+      verified: false,
+    };
+  },
+
+  getGuidance(): PostFixGuidance {
+    return {
+      needsTerminalRestart: false,
+      needsReboot: false,
+      verifyCommands: [
+        'git config --global user.name',
+        'git config --global user.email',
+      ],
+      notes: [
+        '如果希望使用不同提交身份，可重新运行 git config --global 手动覆盖',
+      ],
+    };
+  },
+
+  getVerificationCommand(): string | string[] {
+    return ['git config --global user.name', 'git config --global user.email'];
+  },
+};
+
+registerFixer(gitIdentityFixer);

--- a/src/fixers/guidance.ts
+++ b/src/fixers/guidance.ts
@@ -1,0 +1,132 @@
+import type { Fixer, FixResult, PostFixGuidance } from './types';
+import type { ScanResult } from '../scanners/types';
+import { registerFixer } from './registry';
+
+interface GuidanceFixerConfig {
+  id: string;
+  scannerId: string;
+  name: string;
+  risk?: 'yellow' | 'red';
+  message: string;
+  nextSteps: string[];
+  verifyCommands?: string[];
+  notes?: string[];
+}
+
+function createGuidanceFixer(config: GuidanceFixerConfig): Fixer {
+  return {
+    id: config.id,
+    name: config.name,
+    risk: config.risk || 'red',
+    scannerIds: [config.scannerId],
+
+    canFix(scanResult: ScanResult): boolean {
+      return scanResult.id === config.scannerId && (scanResult.status === 'warn' || scanResult.status === 'fail');
+    },
+
+    async execute(_scanResult: ScanResult, dryRun?: boolean): Promise<FixResult> {
+      return {
+        success: true,
+        message: dryRun ? `[dry-run] ${config.message}` : config.message,
+        verified: false,
+        nextSteps: [...config.nextSteps],
+      };
+    },
+
+    getGuidance(): PostFixGuidance {
+      return {
+        needsTerminalRestart: false,
+        needsReboot: false,
+        verifyCommands: config.verifyCommands,
+        notes: config.notes,
+      };
+    },
+
+    getVerificationCommand(): string | string[] | undefined {
+      if (!config.verifyCommands?.length) return undefined;
+      return config.verifyCommands.length === 1 ? config.verifyCommands[0] : config.verifyCommands;
+    },
+  };
+}
+
+[
+  createGuidanceFixer({
+    id: 'git-credential-health-fixer',
+    scannerId: 'git-credential-health',
+    name: 'Git 凭据链路指引',
+    risk: 'red',
+    message: '请按推荐方式补齐 Git 凭据链路',
+    nextSteps: [
+      'HTTPS 推荐: git config --global credential.helper osxkeychain',
+      'SSH 推荐: ssh-keygen -t ed25519 -C "you@example.com"',
+      '将公钥添加到 GitHub/GitLab 后重试 clone / push',
+    ],
+    verifyCommands: [
+      'git config --global credential.helper',
+      'ls ~/.ssh',
+    ],
+  }),
+  createGuidanceFixer({
+    id: 'admin-perms-fixer',
+    scannerId: 'admin-perms',
+    name: '管理员权限指引',
+    risk: 'red',
+    message: '当前用户权限受限，需要管理员协助完成部分系统配置',
+    nextSteps: [
+      '切换到管理员账号重新执行需要系统权限的修复',
+      '或让管理员为当前账号授予 sudo 权限',
+      '仅需单次管理员操作时，可由管理员在场执行对应命令',
+    ],
+    verifyCommands: [
+      'groups',
+      'sudo -n true && echo sudo_ok || echo sudo_limited',
+    ],
+  }),
+  createGuidanceFixer({
+    id: 'proxy-config-fixer',
+    scannerId: 'proxy-config',
+    name: '代理配置检查指引',
+    risk: 'yellow',
+    message: '请核对代理环境变量是否指向有效代理地址',
+    nextSteps: [
+      '查看当前代理: env | grep -i proxy',
+      '如需移除当前 shell 代理: unset HTTP_PROXY HTTPS_PROXY http_proxy https_proxy',
+      '如代理长期失效，请检查 ~/.zshrc ~/.bashrc 或终端配置中的代理导出语句',
+    ],
+    verifyCommands: [
+      'env | grep -i proxy',
+    ],
+  }),
+  createGuidanceFixer({
+    id: 'dns-resolution-fixer',
+    scannerId: 'dns-resolution',
+    name: 'DNS 诊断指引',
+    risk: 'red',
+    message: 'DNS 解析异常，建议先排查本机 DNS 与网络出口设置',
+    nextSteps: [
+      '运行: scutil --dns | head -40',
+      '尝试切换到稳定 DNS，如 1.1.1.1 或 223.5.5.5',
+      '如处于公司网络或代理环境，检查 VPN / 代理是否篡改 DNS',
+    ],
+    verifyCommands: [
+      'nslookup github.com',
+      'nslookup registry.npmjs.org',
+    ],
+  }),
+  createGuidanceFixer({
+    id: 'ssl-certs-fixer',
+    scannerId: 'ssl-certs',
+    name: 'SSL 证书诊断指引',
+    risk: 'red',
+    message: 'HTTPS 握手异常，建议排查系统证书、代理拦截或企业中间人证书',
+    nextSteps: [
+      '运行: curl -Iv https://github.com',
+      '如使用代理或公司网络，确认是否存在 HTTPS 中间人证书拦截',
+      '必要时检查系统钥匙串中的自定义根证书或安全软件注入',
+    ],
+    verifyCommands: [
+      'curl -Iv https://github.com',
+      'curl -Iv https://registry.npmjs.org',
+    ],
+  }),
+].forEach(registerFixer);

--- a/src/fixers/guidance.ts
+++ b/src/fixers/guidance.ts
@@ -51,6 +51,25 @@ function createGuidanceFixer(config: GuidanceFixerConfig): Fixer {
 
 [
   createGuidanceFixer({
+    id: 'git-identity-guidance-fixer',
+    scannerId: 'git-identity',
+    name: 'Git 身份配置指引',
+    risk: 'yellow',
+    message: '缺少可复用的 Git 身份信息，请先提供 name/email 后再配置',
+    nextSteps: [
+      '设置环境变量 MAC_AICHECK_GIT_NAME 和 MAC_AICHECK_GIT_EMAIL 后重新执行修复',
+      '或手动运行: git config --global user.name "Your Name"',
+      '或手动运行: git config --global user.email "you@example.com"',
+    ],
+    verifyCommands: [
+      'git config --global user.name',
+      'git config --global user.email',
+    ],
+    notes: [
+      '自动修复只会在能够安全推断出 name/email 时执行，避免写入错误身份',
+    ],
+  }),
+  createGuidanceFixer({
     id: 'git-credential-health-fixer',
     scannerId: 'git-credential-health',
     name: 'Git 凭据链路指引',

--- a/src/fixers/index.ts
+++ b/src/fixers/index.ts
@@ -13,6 +13,10 @@ import './python-versions';
 import './xcode';
 import './developer-mode';
 import './disk-space';
+import './git-identity';
+import './uv-package-manager';
+import './ai-tools';
+import './guidance';
 
 // Re-export orchestrator (and its types for backward compatibility)
 export {

--- a/src/fixers/presentation.ts
+++ b/src/fixers/presentation.ts
@@ -1,0 +1,68 @@
+import type { Fixer, FixerRisk } from './types';
+import type { ScanResult } from '../scanners/types';
+
+export interface FixRiskPresentation {
+  risk: FixerRisk;
+  title: string;
+  buttonLabel: string;
+  accent: string;
+  background: string;
+  text: string;
+  border: string;
+  weight: number;
+}
+
+const PRESENTATION_BY_RISK: Record<FixerRisk, FixRiskPresentation> = {
+  green: {
+    risk: 'green',
+    title: '立即处理',
+    buttonLabel: '立即修复',
+    accent: '#22c55e',
+    background: 'rgba(34,197,94,.10)',
+    text: '#dcfce7',
+    border: 'rgba(34,197,94,.25)',
+    weight: 0,
+  },
+  yellow: {
+    risk: 'yellow',
+    title: '建议处理',
+    buttonLabel: '查看并执行',
+    accent: '#eab308',
+    background: 'rgba(234,179,8,.10)',
+    text: '#fef3c7',
+    border: 'rgba(234,179,8,.28)',
+    weight: 1,
+  },
+  red: {
+    risk: 'red',
+    title: '手动处理',
+    buttonLabel: '查看指引',
+    accent: '#f97316',
+    background: 'rgba(249,115,22,.10)',
+    text: '#ffedd5',
+    border: 'rgba(249,115,22,.28)',
+    weight: 2,
+  },
+};
+
+export function getFixRiskPresentation(fixer: Fixer): FixRiskPresentation {
+  return PRESENTATION_BY_RISK[fixer.risk];
+}
+
+export function rankIssue(scanResult: ScanResult, fixer?: Fixer): number {
+  const statusWeight = scanResult.status === 'fail' ? 0 : scanResult.status === 'warn' ? 10 : 20;
+  const fixerWeight = fixer ? getFixRiskPresentation(fixer).weight : 9;
+  return statusWeight + fixerWeight;
+}
+
+export function sortIssuesByPriority(results: ScanResult[], resolveFixer: (result: ScanResult) => Fixer | undefined): ScanResult[] {
+  return [...results].sort((left, right) => {
+    const leftFixer = resolveFixer(left);
+    const rightFixer = resolveFixer(right);
+
+    const rankDiff = rankIssue(left, leftFixer) - rankIssue(right, rightFixer);
+    if (rankDiff !== 0) return rankDiff;
+
+    return left.name.localeCompare(right.name, 'zh-CN');
+  });
+}

--- a/src/fixers/uv-package-manager.ts
+++ b/src/fixers/uv-package-manager.ts
@@ -1,0 +1,85 @@
+import type { Fixer, FixResult, PostFixGuidance } from './types';
+import type { ScanResult } from '../scanners/types';
+import { registerFixer } from './registry';
+import { classifyError, ERROR_MESSAGES } from './errors';
+import { commandExists, runCommand } from '../executor/index';
+
+const INSTALL_TIMEOUT = 180_000;
+
+const uvFixer: Fixer = {
+  id: 'uv-package-manager-fixer',
+  name: 'uv 安装',
+  risk: 'green',
+  scannerIds: ['uv-package-manager'],
+
+  canFix(scanResult: ScanResult): boolean {
+    return scanResult.id === 'uv-package-manager' && (scanResult.status === 'warn' || scanResult.status === 'fail');
+  },
+
+  async execute(_scanResult: ScanResult, dryRun?: boolean): Promise<FixResult> {
+    if (dryRun) {
+      return {
+        success: true,
+        message: '[dry-run] 将尝试通过 Homebrew 或 pip 安装 uv',
+        verified: false,
+      };
+    }
+
+    const attempts: string[] = [];
+
+    if (commandExists('brew')) {
+      const brewResult = runCommand('brew list uv >/dev/null 2>&1 && brew upgrade uv || brew install uv', INSTALL_TIMEOUT);
+      if (brewResult.exitCode === 0) {
+        return {
+          success: true,
+          message: 'uv 已通过 Homebrew 安装/升级',
+          verified: false,
+        };
+      }
+      attempts.push(`Homebrew: ${brewResult.stderr || brewResult.stdout || 'failed'}`);
+    }
+
+    if (commandExists('python3')) {
+      const pipResult = runCommand('python3 -m pip install --user -U uv', INSTALL_TIMEOUT);
+      if (pipResult.exitCode === 0) {
+        return {
+          success: true,
+          message: 'uv 已通过 pip 安装/升级',
+          verified: false,
+        };
+      }
+      attempts.push(`pip: ${pipResult.stderr || pipResult.stdout || 'failed'}`);
+    }
+
+    const combined = attempts.join('\n') || '未找到可用安装方式';
+    const classified = classifyError(1, combined, combined);
+    const errMsg = ERROR_MESSAGES[classified.category];
+    return {
+      success: false,
+      message: `uv 安装失败: ${errMsg.title}，${errMsg.suggestion}`,
+      verified: false,
+      nextSteps: [
+        ...attempts,
+        '如需手动安装，可运行: brew install uv',
+        '或运行: python3 -m pip install --user -U uv',
+      ],
+    };
+  },
+
+  getGuidance(): PostFixGuidance {
+    return {
+      needsTerminalRestart: true,
+      needsReboot: false,
+      verifyCommands: ['uv --version'],
+      notes: [
+        '如果当前终端仍找不到 uv，请重新打开终端让 PATH 生效',
+      ],
+    };
+  },
+
+  getVerificationCommand(): string | string[] {
+    return 'uv --version';
+  },
+};
+
+registerFixer(uvFixer);

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,10 +2,12 @@
 
 import { scanAll } from './scanners/index';
 import { fixAll, getFixerById, getFixerForScanResult } from './fixers/index';
+import { getFixRiskPresentation, sortIssuesByPriority } from './fixers/presentation';
 import { calculateScore } from './scoring/calculator';
 import { createPayload, saveLocal, stashData, buildClaimUrl, submitFeedback } from './api/aicoevo-client';
 import { getInstallers, getAllowedCommands } from './installers/index';
 import { getAgentLocalStatus, enableAgentExperience, pauseAgentUploads, syncAgentEvents } from './agent/local-state';
+import { shouldUploadScan } from './cli/options';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as http from 'http';
@@ -71,12 +73,19 @@ function renderServePage(): string {
 
   const score = data.score?.score ?? 0;
   const label = data.score?.label ?? '';
-  const issues = data.results.filter(item => item.status === 'fail' || item.status === 'warn');
+  const issues = sortIssuesByPriority(
+    data.results.filter(item => item.status === 'fail' || item.status === 'warn'),
+    item => getFixerForScanResult(item),
+  );
   const cards = issues.map((item) => {
-    const fixable = Boolean(getFixerForScanResult(item));
+    const fixer = getFixerForScanResult(item);
+    const presentation = fixer ? getFixRiskPresentation(fixer) : null;
     const detail = item.detail ? `<pre style="white-space:pre-wrap;background:#0f172a;border:1px solid #334155;border-radius:8px;padding:12px;overflow:auto">${escapeHtml(item.detail)}</pre>` : '';
-    const fixButton = fixable
-      ? `<button onclick="runFix('${escapeHtml(item.id)}', this)" style="margin-top:12px;padding:10px 14px;border-radius:8px;border:0;background:#22c55e;color:#04130a;font-weight:700;cursor:pointer">尝试修复</button>`
+    const riskChip = presentation
+      ? `<span style="display:inline-flex;align-items:center;padding:4px 8px;border-radius:999px;font-size:12px;font-weight:700;background:${presentation.background};color:${presentation.text};border:1px solid ${presentation.border}">${escapeHtml(presentation.title)}</span>`
+      : `<span style="display:inline-flex;align-items:center;padding:4px 8px;border-radius:999px;font-size:12px;font-weight:700;background:rgba(148,163,184,.12);color:#cbd5e1;border:1px solid rgba(148,163,184,.25)">仅检测</span>`;
+    const fixButton = presentation
+      ? `<button onclick="runFix('${escapeHtml(item.id)}', this)" style="margin-top:12px;padding:10px 14px;border-radius:8px;border:0;background:${presentation.accent};color:#04130a;font-weight:700;cursor:pointer">${escapeHtml(presentation.buttonLabel)}</button>`
       : `<div style="margin-top:12px;color:#94a3b8;font-size:13px">当前没有自动修复器</div>`;
     return `<section style="border:1px solid #334155;border-radius:12px;padding:16px;background:#111827">
       <div style="display:flex;justify-content:space-between;gap:12px;align-items:flex-start">
@@ -84,6 +93,7 @@ function renderServePage(): string {
           <div style="font-size:18px;font-weight:700">${escapeHtml(item.name)}</div>
           <div style="font-size:13px;color:#94a3b8">${escapeHtml(item.id)} · ${escapeHtml(item.category)} · ${escapeHtml(item.status)}</div>
         </div>
+        ${riskChip}
       </div>
       <p style="margin:12px 0;color:#e5e7eb">${escapeHtml(item.message)}</p>
       ${detail}
@@ -491,24 +501,32 @@ function serveHttp() {
   });
 }
 
-async function runScan(serve: boolean) {
+async function runScan(serve: boolean, upload: boolean) {
   console.log(`[*] MacAICheck v${VERSION} scanning...\n`);
   const results = await scanAll();
   const score = calculateScore(results);
   // 保存本地 + 上报 aicoevo.net 获取认领 token
   const payload = createPayload(results, score);
   try {
-    saveLocal(payload);
-    stashData(payload)
-      .then(({ token, claim_url }) => {
-        const claimUrl = claim_url || buildClaimUrl(token);
-        console.log('\n[+] 扫描结果已上传，请在浏览器打开认领你的环境报告:');
-        console.log(`    ${claimUrl}\n`);
-      })
-      .catch((err) => {
-        console.error('\n[-] 上传失败:', err instanceof Error ? err.message : String(err));
-        console.error('    扫描结果已保存在本地，请检查网络后重新运行上传\n');
-      });
+    const localPath = saveLocal(payload);
+    if (localPath) {
+      console.log(`[+] 扫描结果已保存到本地: ${localPath}`);
+    }
+
+    if (upload) {
+      stashData(payload)
+        .then(({ token, claim_url }) => {
+          const claimUrl = claim_url || buildClaimUrl(token);
+          console.log('\n[+] 扫描结果已上传，请在浏览器打开认领你的环境报告:');
+          console.log(`    ${claimUrl}\n`);
+        })
+        .catch((err) => {
+          console.error('\n[-] 上传失败:', err instanceof Error ? err.message : String(err));
+          console.error('    扫描结果已保存在本地，请检查网络后重新运行上传\n');
+        });
+    } else {
+      console.log('[i] 默认不上传扫描结果。使用 --upload 或 mac-aicheck upload 获取认领链接。\n');
+    }
   } catch (e) { console.error('[MacAICheck] 保存本地报告失败:', e instanceof Error ? e.message : String(e)); }
   const passed = results.filter(r => r.status === 'pass').length;
   const warn = results.filter(r => r.status === 'warn').length;
@@ -527,12 +545,13 @@ async function runScan(serve: boolean) {
 }
 
 const args = process.argv.slice(2);
+const upload = shouldUploadScan(args);
 if (args.includes('--serve') || args.includes('--web')) {
-  runScan(true).catch(console.error);
+  runScan(true, upload).catch(console.error);
 } else if (args.includes('--json')) {
-  runScan(false).then(r => { if (r) console.log(JSON.stringify(r, null, 2)); }).catch(console.error);
+  runScan(false, upload).then(r => { if (r) console.log(JSON.stringify(r, null, 2)); }).catch(console.error);
 } else if (args.includes('--help')) {
-  console.log('MacAICheck - AI Dev Environment Checker\nUsage:\n  mac-aicheck          Run diagnosis\n  mac-aicheck --serve   Start Web UI\n  mac-aicheck --json    JSON output\n  mac-aicheck agent     Agent Lite commands (enable/install-hook/sync, etc.)');
+  console.log('MacAICheck - AI Dev Environment Checker\nUsage:\n  mac-aicheck           Run diagnosis (local only)\n  mac-aicheck --upload  Run diagnosis and upload for claim link\n  mac-aicheck upload    Upload-enabled diagnosis shortcut\n  mac-aicheck --serve   Start Web UI\n  mac-aicheck --json    JSON output\n  mac-aicheck agent     Agent Lite commands (enable/install-hook/sync, etc.)');
 } else if (args.includes('agent')) {
   // Agent Lite CLI 子命令
   const agentArgs = args.slice(args.indexOf('agent') + 1);
@@ -540,6 +559,8 @@ if (args.includes('--serve') || args.includes('--web')) {
   const agentCmd = path.join(__dirname, '../bin/mac-aicheck-agent');
   const proc = spawnAsync('bash', [agentCmd, ...agentArgs], { stdio: 'inherit' });
   proc.on('close', (code: number | null) => { process.exitCode = code ?? 0; });
+} else if (args.includes('upload')) {
+  runScan(false, true).catch(console.error);
 } else if (args.includes('fix')) {
   const dryRun = args.includes('--dry-run');
   const riskLevel = args.includes('--green') ? 'green' :
@@ -555,10 +576,12 @@ if (args.includes('--serve') || args.includes('--web')) {
     for (const r of result.results) {
       if (r.fixResult) {
         const icon = r.fixResult.success ? '[+]' : '[-]';
-        console.log(`${icon} ${r.scannerId}: ${r.fixResult.message}`);
+        const fixer = r.fixerId ? getFixerById(r.fixerId) : undefined;
+        const riskTag = fixer ? `[${fixer.risk.toUpperCase()}] ` : '';
+        const fixerName = fixer ? ` (${fixer.name})` : '';
+        console.log(`${icon} ${riskTag}${r.scannerId}${fixerName}: ${r.fixResult.message}`);
 
-        if (r.fixerId) {
-          const fixer = getFixerById(r.fixerId);
+        if (fixer) {
           const verificationCmd = fixer?.getVerificationCommand?.();
           if (verificationCmd) {
             const cmds = Array.isArray(verificationCmd) ? verificationCmd : [verificationCmd];
@@ -578,5 +601,5 @@ if (args.includes('--serve') || args.includes('--web')) {
     }
   }).catch(console.error);
 } else {
-  runScan(false).catch(console.error);
+  runScan(false, false).catch(console.error);
 }

--- a/src/scanners/apple-platform.ts
+++ b/src/scanners/apple-platform.ts
@@ -1,0 +1,20 @@
+import { runCommand } from '../executor/index';
+
+const COMMAND_TIMEOUT_MS = 3000;
+
+export function getApplePlatform(): { isAppleSilicon: boolean; chip: string } {
+  const arch = runCommand('uname -m', COMMAND_TIMEOUT_MS).stdout.trim();
+  const chip = runCommand('sysctl -n machdep.cpu.brand_string 2>/dev/null', COMMAND_TIMEOUT_MS).stdout.trim();
+
+  return {
+    isAppleSilicon: arch === 'arm64' || chip.includes('Apple'),
+    chip: chip || arch || 'unknown',
+  };
+}
+
+export function hasRosettaInstalled(): boolean {
+  return runCommand(
+    'pkgutil --pkg-info=com.apple.pkg.RosettaUpdateLegacy 2>/dev/null',
+    COMMAND_TIMEOUT_MS,
+  ).exitCode === 0;
+}

--- a/src/scanners/apple-silicon.ts
+++ b/src/scanners/apple-silicon.ts
@@ -1,17 +1,17 @@
 import type { Scanner, ScanResult } from './types';
-import { runCommand, commandExists } from '../executor/index';
 import { registerScanner } from './registry';
+import { getApplePlatform, hasRosettaInstalled } from './apple-platform';
 
 const scanner: Scanner = {
   id: 'apple-silicon',
   name: 'Apple Silicon 检测',
   category: 'apple',
+  affectsScore: false,
 
   async scan(): Promise<ScanResult> {
-    const uname = runCommand('uname -m', 3000);
-    const isArm = uname.stdout.trim() === 'arm64';
+    const { isAppleSilicon, chip } = getApplePlatform();
 
-    if (!isArm) {
+    if (!isAppleSilicon) {
       return {
         id: this.id, name: this.name, category: this.category,
         status: 'pass',
@@ -19,17 +19,13 @@ const scanner: Scanner = {
       };
     }
 
-    const sysctl = runCommand('sysctl -n machdep.cpu.brand_string', 3000);
-    const chip = sysctl.stdout.trim();
-    const hasRosetta = commandExists('rosetta');
-
     return {
       id: this.id, name: this.name, category: this.category,
-      status: hasRosetta ? 'pass' : 'warn',
-      error_type: hasRosetta ? undefined : 'incompatible',
-      message: hasRosetta
-        ? `Apple Silicon (${chip}) + Rosetta 2 已安装`
-        : `Apple Silicon (${chip})，建议安装 Rosetta 2`,
+      status: 'pass',
+      message: `Apple Silicon (${chip})`,
+      detail: hasRosettaInstalled()
+        ? 'Rosetta 2 已安装，可兼容多数 x86 CLI 工具'
+        : 'Rosetta 2 未安装。仅在需要运行 x86 CLI 工具时再安装即可',
     };
   },
 };

--- a/src/scanners/dns-resolution.ts
+++ b/src/scanners/dns-resolution.ts
@@ -6,10 +6,11 @@ const scanner: Scanner = {
   id: 'dns-resolution',
   name: 'DNS 解析',
   category: 'network',
+  affectsScore: false,
 
   async scan(): Promise<ScanResult> {
-    // 测试常用域名解析速度
-    const sites = ['github.com', 'google.com', 'npmjs.org'];
+    // 测试与开发环境更相关、且在国内外都更有代表性的域名
+    const sites = ['github.com', 'registry.npmjs.org', 'pypi.org'];
     const results: string[] = [];
 
     const checks = sites.map(async (site) => {
@@ -23,14 +24,17 @@ const scanner: Scanner = {
 
     const failures = results.filter(r => r.includes('FAIL'));
     if (failures.length > 0) {
-      return { id: this.id, name: this.name, category: this.category, status: 'fail',
+      const status = failures.length === sites.length ? 'fail' : 'warn';
+      return { id: this.id, name: this.name, category: this.category, status,
         error_type: 'network',
-        message: `DNS 解析失败: ${failures.join(', ')}` };
+        message: `DNS 解析异常: ${failures.join(', ')}`,
+        detail: results.join('\n') };
     }
 
     const avg = results.filter(r => !r.includes('FAIL')).map(r => parseInt(r.split(':')[1])).reduce((a, b) => a + b, 0) / results.filter(r => !r.includes('FAIL')).length;
     return { id: this.id, name: this.name, category: this.category, status: 'pass',
-      message: `DNS 解析正常 (avg ${Math.round(avg)}ms)` };
+      message: `DNS 解析正常 (avg ${Math.round(avg)}ms)`,
+      detail: results.join('\n') };
   },
 };
 registerScanner(scanner);

--- a/src/scanners/npm-mirror.ts
+++ b/src/scanners/npm-mirror.ts
@@ -2,6 +2,10 @@ import type { Scanner, ScanResult } from './types';
 import { runCommand } from '../executor/index';
 import { registerScanner } from './registry';
 
+function normalizeRegistry(registry: string): string {
+  return registry.trim().replace(/\/+$/, '').toLowerCase();
+}
+
 const scanner: Scanner = {
   id: 'npm-mirror',
   name: 'npm 镜像源',
@@ -10,11 +14,25 @@ const scanner: Scanner = {
   async scan(): Promise<ScanResult> {
     const { stdout } = runCommand('npm config get registry', 5000);
     const registry = stdout.trim();
-    const isChina = registry.includes('npmmirror.com') ||
-                    registry.includes('taobao.org') ||
-                    registry.includes('cnpm');
-    const isOffical = registry === 'https://registry.npmjs.org/';
-    if (isOffical) {
+    const normalized = normalizeRegistry(registry);
+
+    if (!normalized) {
+      return {
+        id: this.id,
+        name: this.name,
+        category: this.category,
+        status: 'unknown',
+        message: '无法读取 npm registry 配置',
+        error_type: 'unknown',
+      };
+    }
+
+    const isChina = normalized.includes('npmmirror.com') ||
+      normalized.includes('taobao.org') ||
+      normalized.includes('cnpm');
+    const isOfficial = normalized === 'https://registry.npmjs.org';
+
+    if (isOfficial) {
       return { id: this.id, name: this.name, category: this.category, status: 'pass',
         message: 'npm 使用官方源 (registry.npmjs.org)' };
     }

--- a/src/scanners/proxy-config.ts
+++ b/src/scanners/proxy-config.ts
@@ -2,10 +2,15 @@ import type { Scanner, ScanResult } from './types';
 import { runCommand } from '../executor/index';
 import { registerScanner } from './registry';
 
+function isLikelyProxyValue(value: string): boolean {
+  return /^(https?|socks5h?):\/\/\S+$/i.test(value.trim());
+}
+
 const scanner: Scanner = {
   id: 'proxy-config',
   name: '代理配置',
   category: 'network',
+  affectsScore: false,
 
   async scan(): Promise<ScanResult> {
     const httpProxy = runCommand('echo $HTTP_PROXY $HTTPS_PROXY $http_proxy $https_proxy | tr " " "\\n" | grep -v "^$" | head -5', 3000).stdout.trim();
@@ -14,9 +19,16 @@ const scanner: Scanner = {
         message: '未检测到代理配置' };
     }
     const lines = httpProxy.split('\n').filter(Boolean);
-    return { id: this.id, name: this.name, category: this.category, status: 'warn',
-      error_type: 'misconfigured',
-      message: `检测到代理: ${lines.join(', ')}` };
+    const invalid = lines.filter(line => !isLikelyProxyValue(line));
+    if (invalid.length > 0) {
+      return { id: this.id, name: this.name, category: this.category, status: 'warn',
+        error_type: 'misconfigured',
+        message: `检测到可能异常的代理配置: ${invalid.join(', ')}`,
+        detail: `当前代理配置:\n${lines.join('\n')}` };
+    }
+    return { id: this.id, name: this.name, category: this.category, status: 'pass',
+      message: `检测到代理配置: ${lines.join(', ')}`,
+      detail: lines.join('\n') };
   },
 };
 registerScanner(scanner);

--- a/src/scanners/rosetta.ts
+++ b/src/scanners/rosetta.ts
@@ -1,6 +1,6 @@
 import type { Scanner, ScanResult } from './types';
-import { runCommand } from '../executor/index';
 import { registerScanner } from './registry';
+import { getApplePlatform, hasRosettaInstalled } from './apple-platform';
 
 const scanner: Scanner = {
   id: 'rosetta',
@@ -8,18 +8,14 @@ const scanner: Scanner = {
   category: 'apple',
 
   async scan(): Promise<ScanResult> {
-    // 检查 Apple Silicon 上是否有 Rosetta 2
-    const { exitCode } = runCommand('sysctl -n machdep.cpu.brand_string 2>/dev/null', 3000);
-    const cpu = runCommand('sysctl -n machdep.cpu.brand_string', 3000).stdout;
-    const isAppleSilicon = cpu.includes('Apple');
+    const { isAppleSilicon } = getApplePlatform();
 
     if (!isAppleSilicon) {
       return { id: this.id, name: this.name, category: this.category, status: 'pass',
         message: '非 Apple Silicon，跳过 Rosetta 检测' };
     }
 
-    const { exitCode: rcheck } = runCommand('pkgutil --pkg-info=com.apple.pkg.RosettaUpdateLegacy 2>/dev/null || echo "not installed"', 3000);
-    if (rcheck !== 0) {
+    if (!hasRosettaInstalled()) {
       return { id: this.id, name: this.name, category: this.category, status: 'warn',
         error_type: 'incompatible',
         message: 'Apple Silicon 但 Rosetta 2 未安装，部分 x86 软件无法运行。安装命令: softwareupdate --install-rosetta' };

--- a/src/scanners/screen-permission.ts
+++ b/src/scanners/screen-permission.ts
@@ -1,22 +1,24 @@
 import type { Scanner, ScanResult } from './types';
-import { runCommand } from '../executor/index';
 import { registerScanner } from './registry';
 
 const scanner: Scanner = {
   id: 'screen-permission',
   name: '屏幕录制权限',
   category: 'apple',
+  affectsScore: false,
+  defaultEnabled: false,
 
   async scan(): Promise<ScanResult> {
-    const tcc = runCommand('tccutil check ScreenCapture 2>/dev/null || echo "unknown"', 3000);
-    const output = tcc.stdout.trim();
-    if (output.includes('ScreenCapture')) {
-      return { id: this.id, name: this.name, category: this.category, status: 'pass',
-        message: '屏幕录制权限已授权' };
-    }
-    return { id: this.id, name: this.name, category: this.category, status: 'fail',
-      message: '屏幕录制权限未授权，请到 系统设置 → 隐私与安全性 → 屏幕录制 添加对应应用',
-      error_type: 'permission' };
+    return {
+      id: this.id,
+      name: this.name,
+      category: this.category,
+      status: 'unknown',
+      message: 'CLI 无法可靠检测当前终端的屏幕录制权限',
+      detail: '如截图、屏幕读取或录屏类工具报权限错误，请到 系统设置 → 隐私与安全性 → 屏幕录制 中授权对应终端或应用。',
+      suggestions: ['系统设置 → 隐私与安全性 → 屏幕录制'],
+      error_type: 'unknown',
+    };
   },
 };
 registerScanner(scanner);

--- a/src/scanners/ssl-certs.ts
+++ b/src/scanners/ssl-certs.ts
@@ -16,10 +16,10 @@ const scanner: Scanner = {
 
     const checks = sites.map(site => {
       const result = runCommand(
-        `curl -s --connect-timeout 5 -o /dev/null -w "%{http_code}" ${site.url} 2>/dev/null || echo "FAIL"`,
+        `curl -s --connect-timeout 5 -o /dev/null -w "%{http_code}" ${site.url} 2>/dev/null`,
         10000,
       );
-      const code = result.stdout.trim();
+      const code = result.exitCode === 0 ? result.stdout.trim() : 'FAIL';
       const ok = code === '200' || code === '301' || code === '302';
       return { ...site, code, ok };
     });

--- a/src/scanners/ssl-certs.ts
+++ b/src/scanners/ssl-certs.ts
@@ -6,21 +6,46 @@ const scanner: Scanner = {
   id: 'ssl-certs',
   name: 'SSL 证书',
   category: 'network',
+  affectsScore: false,
 
   async scan(): Promise<ScanResult> {
-    // Mac: 通过 curl 测试 SSL 握手，检测系统 CA 证书是否正常
-    const result = runCommand(
-      'curl -s --connect-timeout 5 -o /dev/null -w "%{http_code}" https://github.com 2>/dev/null || echo "FAIL"',
-      10000
-    );
-    const httpCode = result.stdout.trim();
-    if (httpCode === '200' || httpCode === '301' || httpCode === '302') {
-      return { id: this.id, name: this.name, category: this.category, status: 'pass',
-        message: `SSL 证书正常（github.com HTTPS 正常, HTTP ${httpCode}）` };
+    const sites = [
+      { name: 'github.com', url: 'https://github.com' },
+      { name: 'registry.npmjs.org', url: 'https://registry.npmjs.org' },
+    ];
+
+    const checks = sites.map(site => {
+      const result = runCommand(
+        `curl -s --connect-timeout 5 -o /dev/null -w "%{http_code}" ${site.url} 2>/dev/null || echo "FAIL"`,
+        10000,
+      );
+      const code = result.stdout.trim();
+      const ok = code === '200' || code === '301' || code === '302';
+      return { ...site, code, ok };
+    });
+
+    const failed = checks.filter(item => !item.ok);
+    if (failed.length === 0) {
+      return {
+        id: this.id,
+        name: this.name,
+        category: this.category,
+        status: 'pass',
+        message: 'SSL 证书正常（常用 HTTPS 站点握手成功）',
+        detail: checks.map(item => `${item.name}: ${item.code}`).join('\n'),
+      };
     }
-    return { id: this.id, name: this.name, category: this.category, status: 'fail',
-      message: `SSL 证书异常（github.com 返回 ${httpCode}）`,
-      error_type: 'network' };
+
+    const status = failed.length === checks.length ? 'fail' : 'warn';
+    return {
+      id: this.id,
+      name: this.name,
+      category: this.category,
+      status,
+      message: `SSL / HTTPS 握手异常: ${failed.map(item => `${item.name}=${item.code}`).join(', ')}`,
+      detail: checks.map(item => `${item.name}: ${item.code}`).join('\n'),
+      error_type: 'network',
+    };
   },
 };
 registerScanner(scanner);

--- a/src/web/render.ts
+++ b/src/web/render.ts
@@ -85,7 +85,7 @@ export function groupByCategory(results: ScanResult[]) {
 
 export const FIX_DEFS = [
   { id:'fix-git-identity', scanner:'git-identity-config', tier:'yellow', name:'配置 Git 全局身份', desc:'设置 user.name 和 user.email', cmd:'git config --global user.name "Your Name" && git config --global user.email "you@example.com"' },
-  { id:'fix-rosetta', scanner:'apple-silicon', tier:'green', name:'安装 Rosetta 2', desc:'让 x86 软件在 Apple Silicon 上运行', cmd:'softwareupdate --install-rosetta --agree-to-license' },
+  { id:'fix-rosetta', scanner:'rosetta', tier:'green', name:'安装 Rosetta 2', desc:'让 x86 软件在 Apple Silicon 上运行', cmd:'softwareupdate --install-rosetta --agree-to-license' },
   { id:'fix-npm-mirror', scanner:'npm-mirror', tier:'green', name:'配置 npm 国内镜像', desc:'切换到 npmmirror.com 加速', cmd:'npm config set registry https://registry.npmmirror.com' },
   { id:'fix-dev-mode', scanner:'developer-mode', tier:'yellow', name:'开启开发者模式', desc:'重启 Mac，在恢复模式操作', cmd:'' },
   { id:'fix-screen-perm', scanner:'screen-permission', tier:'red', name:'授予屏幕录制权限', desc:'系统设置 → 隐私与安全性 → 屏幕录制', cmd:'' },

--- a/tests/cli-options.test.ts
+++ b/tests/cli-options.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest';
+import { shouldUploadScan } from '../src/cli/options';
+
+describe('cli upload options', () => {
+  it('keeps plain diagnosis local by default', () => {
+    expect(shouldUploadScan([])).toBe(false);
+    expect(shouldUploadScan(['--json'])).toBe(false);
+    expect(shouldUploadScan(['--serve'])).toBe(false);
+  });
+
+  it('enables upload only when explicitly requested', () => {
+    expect(shouldUploadScan(['--upload'])).toBe(true);
+    expect(shouldUploadScan(['upload'])).toBe(true);
+    expect(shouldUploadScan(['--serve', '--upload'])).toBe(true);
+  });
+});

--- a/tests/fix-presentation.test.ts
+++ b/tests/fix-presentation.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import type { ScanResult } from '../src/scanners/types';
+import type { Fixer } from '../src/fixers/types';
+import { getFixRiskPresentation, sortIssuesByPriority } from '../src/fixers/presentation';
+
+describe('fix presentation helpers', () => {
+  it('maps risk levels to UI labels', () => {
+    expect(getFixRiskPresentation({ risk: 'green' } as Fixer).buttonLabel).toBe('立即修复');
+    expect(getFixRiskPresentation({ risk: 'yellow' } as Fixer).buttonLabel).toBe('查看并执行');
+    expect(getFixRiskPresentation({ risk: 'red' } as Fixer).buttonLabel).toBe('查看指引');
+  });
+
+  it('sorts fail items ahead of warn items and actionable fixers ahead of guidance-only ones', () => {
+    const results: ScanResult[] = [
+      { id: 'warn-red', name: 'Warn Red', category: 'network', status: 'warn', message: '' },
+      { id: 'fail-yellow', name: 'Fail Yellow', category: 'toolchain', status: 'fail', message: '' },
+      { id: 'fail-green', name: 'Fail Green', category: 'toolchain', status: 'fail', message: '' },
+      { id: 'warn-none', name: 'Warn None', category: 'network', status: 'warn', message: '' },
+    ];
+
+    const fixers = new Map<string, Fixer>([
+      ['warn-red', { id: '1', name: 'red', risk: 'red', canFix: async () => true as any, execute: async () => ({ success: true, message: '', verified: false }) } as unknown as Fixer],
+      ['fail-yellow', { id: '2', name: 'yellow', risk: 'yellow', canFix: async () => true as any, execute: async () => ({ success: true, message: '', verified: false }) } as unknown as Fixer],
+      ['fail-green', { id: '3', name: 'green', risk: 'green', canFix: async () => true as any, execute: async () => ({ success: true, message: '', verified: false }) } as unknown as Fixer],
+    ]);
+
+    const sorted = sortIssuesByPriority(results, item => fixers.get(item.id));
+    expect(sorted.map(item => item.id)).toEqual(['fail-green', 'fail-yellow', 'warn-red', 'warn-none']);
+  });
+});

--- a/tests/fixers.test.ts
+++ b/tests/fixers.test.ts
@@ -19,7 +19,7 @@ describe('fixer registry (pre-registered)', () => {
   });
 
   it('getFixerByScannerId returns fixer matching scannerIds', () => {
-    // git-fixer handles 'git' and 'git-identity-config'
+    // git-fixer handles git installation
     const fixer = getFixerByScannerId('git');
     expect(fixer?.id).toBe('git-fixer');
   });
@@ -31,10 +31,22 @@ describe('fixer registry (pre-registered)', () => {
     expect(fixer?.id).toBe('git-fixer');
   });
 
-  it('git identity 的 warn 状态不会再误匹配到 fixer', () => {
+  it('git identity 的 warn 状态会匹配到专用 fixer', () => {
     const scanResult: ScanResult = { id: 'git-identity', name: 'Git 身份配置', category: 'toolchain', status: 'warn', message: '' };
     const fixer = getFixerForScanResult(scanResult);
-    expect(fixer).toBeUndefined();
+    expect(fixer?.id).toBe('git-identity-fixer');
+  });
+
+  it('Claude Code 的 warn 状态会匹配到安装 fixer', () => {
+    const scanResult: ScanResult = { id: 'claude-code', name: 'Claude Code', category: 'ai-tools', status: 'warn', message: '' };
+    const fixer = getFixerForScanResult(scanResult);
+    expect(fixer?.id).toBe('claude-code-fixer');
+  });
+
+  it('Git 凭据链路的 warn 状态会匹配到指导 fixer', () => {
+    const scanResult: ScanResult = { id: 'git-credential-health', name: 'Git 凭据链路检测', category: 'toolchain', status: 'warn', message: '' };
+    const fixer = getFixerForScanResult(scanResult);
+    expect(fixer?.id).toBe('git-credential-health-fixer');
   });
 
   it('验证状态 fail→fail 不再误判为 warn', () => {

--- a/tests/fixers.test.ts
+++ b/tests/fixers.test.ts
@@ -1,10 +1,28 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import '../src/scanners/index'; // register scanners
 import '../src/fixers/index'; // trigger side-effect fixer registrations
 import { registerFixer, getFixers, getFixerById, getFixerForScanResult, getFixerByScannerId, clearFixers } from '../src/fixers/registry';
 import { determineVerificationStatus } from '../src/fixers/verify';
 import type { Fixer } from '../src/fixers/types';
 import type { ScanResult } from '../src/scanners/types';
+import { _test } from '../src/executor/index';
+
+const originalGitName = process.env.MAC_AICHECK_GIT_NAME;
+const originalGitEmail = process.env.MAC_AICHECK_GIT_EMAIL;
+
+afterEach(() => {
+  _test.mockExecSync = null;
+  if (originalGitName === undefined) {
+    delete process.env.MAC_AICHECK_GIT_NAME;
+  } else {
+    process.env.MAC_AICHECK_GIT_NAME = originalGitName;
+  }
+  if (originalGitEmail === undefined) {
+    delete process.env.MAC_AICHECK_GIT_EMAIL;
+  } else {
+    process.env.MAC_AICHECK_GIT_EMAIL = originalGitEmail;
+  }
+});
 
 // Tests that depend on pre-registered fixers: do NOT call clearFixers()
 describe('fixer registry (pre-registered)', () => {
@@ -32,9 +50,37 @@ describe('fixer registry (pre-registered)', () => {
   });
 
   it('git identity 的 warn 状态会匹配到专用 fixer', () => {
+    process.env.MAC_AICHECK_GIT_NAME = 'Test User';
+    process.env.MAC_AICHECK_GIT_EMAIL = 'test@example.com';
+    _test.mockExecSync = (cmd: string) => {
+      if (cmd.includes('which git') || cmd.includes('command -v git')) {
+        return Buffer.from('/usr/bin/git\n');
+      }
+      throw new Error(`unexpected command: ${cmd}`);
+    };
+
     const scanResult: ScanResult = { id: 'git-identity', name: 'Git 身份配置', category: 'toolchain', status: 'warn', message: '' };
     const fixer = getFixerForScanResult(scanResult);
     expect(fixer?.id).toBe('git-identity-fixer');
+  });
+
+  it('git identity 在缺少可用身份信息时回退到指导 fixer', () => {
+    delete process.env.MAC_AICHECK_GIT_NAME;
+    delete process.env.MAC_AICHECK_GIT_EMAIL;
+    _test.mockExecSync = (cmd: string) => {
+      if (cmd.includes('which git') || cmd.includes('command -v git')) {
+        return Buffer.from('/usr/bin/git\n');
+      }
+      if (cmd.includes('git config --global user.name')) return Buffer.from('');
+      if (cmd.includes('git config --global user.email')) return Buffer.from('');
+      if (cmd.includes('id -F')) return Buffer.from('');
+      if (cmd.includes('whoami')) return Buffer.from('');
+      throw new Error(`unexpected command: ${cmd}`);
+    };
+
+    const scanResult: ScanResult = { id: 'git-identity', name: 'Git 身份配置', category: 'toolchain', status: 'warn', message: '' };
+    const fixer = getFixerForScanResult(scanResult);
+    expect(fixer?.id).toBe('git-identity-guidance-fixer');
   });
 
   it('Claude Code 的 warn 状态会匹配到安装 fixer', () => {

--- a/tests/scanner-regressions.test.ts
+++ b/tests/scanner-regressions.test.ts
@@ -128,7 +128,7 @@ describe('scanner regressions', () => {
   it('ssl-certs downgrades partial HTTPS failures to warn', async () => {
     _test.mockExecSync = (cmd: string) => {
       if (cmd.includes('https://github.com')) return Buffer.from('200');
-      if (cmd.includes('https://registry.npmjs.org')) return Buffer.from('FAIL');
+      if (cmd.includes('https://registry.npmjs.org')) throw commandError(60, '000');
       throw commandError();
     };
 
@@ -139,5 +139,7 @@ describe('scanner regressions', () => {
     expect(result.status).toBe('warn');
     expect(result.message).toContain('握手异常');
     expect(result.detail).toContain('github.com: 200');
+    expect(result.detail).toContain('registry.npmjs.org: FAIL');
+    expect(result.detail).not.toContain('000FAIL');
   });
 });

--- a/tests/scanner-regressions.test.ts
+++ b/tests/scanner-regressions.test.ts
@@ -1,0 +1,143 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import '../src/scanners/index';
+import { getScannerById, getScanners } from '../src/scanners/registry';
+import { _test } from '../src/executor/index';
+
+function commandError(status = 1, stdout = '', stderr = ''): Error & {
+  status: number;
+  stdout: Buffer;
+  stderr: Buffer;
+} {
+  const error = new Error('command failed') as Error & {
+    status: number;
+    stdout: Buffer;
+    stderr: Buffer;
+  };
+  error.status = status;
+  error.stdout = Buffer.from(stdout);
+  error.stderr = Buffer.from(stderr);
+  return error;
+}
+
+afterEach(() => {
+  _test.mockExecSync = null;
+});
+
+describe('scanner regressions', () => {
+  it('npm-mirror accepts the official registry without a trailing slash', async () => {
+    _test.mockExecSync = (cmd: string) => {
+      if (cmd === 'npm config get registry') {
+        return Buffer.from('https://registry.npmjs.org\n');
+      }
+      throw commandError();
+    };
+
+    const scanner = getScannerById('npm-mirror');
+    expect(scanner).toBeDefined();
+
+    const result = await scanner!.scan();
+    expect(result.status).toBe('pass');
+    expect(result.message).toContain('官方源');
+  });
+
+  it('rosetta warns on Apple Silicon when pkgutil reports it is not installed', async () => {
+    _test.mockExecSync = (cmd: string) => {
+      if (cmd === 'uname -m') return Buffer.from('arm64\n');
+      if (cmd === 'sysctl -n machdep.cpu.brand_string 2>/dev/null') return Buffer.from('Apple M4\n');
+      if (cmd === 'pkgutil --pkg-info=com.apple.pkg.RosettaUpdateLegacy 2>/dev/null') {
+        throw commandError(1);
+      }
+      throw commandError();
+    };
+
+    const scanner = getScannerById('rosetta');
+    expect(scanner).toBeDefined();
+
+    const result = await scanner!.scan();
+    expect(result.status).toBe('warn');
+    expect(result.message).toContain('未安装');
+  });
+
+  it('apple-silicon is informational and does not warn when Rosetta is missing', async () => {
+    _test.mockExecSync = (cmd: string) => {
+      if (cmd === 'uname -m') return Buffer.from('arm64\n');
+      if (cmd === 'sysctl -n machdep.cpu.brand_string 2>/dev/null') return Buffer.from('Apple M4\n');
+      if (cmd === 'pkgutil --pkg-info=com.apple.pkg.RosettaUpdateLegacy 2>/dev/null') {
+        throw commandError(1);
+      }
+      throw commandError();
+    };
+
+    const scanner = getScannerById('apple-silicon');
+    expect(scanner).toBeDefined();
+
+    const result = await scanner!.scan();
+    expect(result.status).toBe('pass');
+    expect(result.message).toContain('Apple Silicon');
+    expect(result.detail).toContain('Rosetta 2 未安装');
+  });
+
+  it('screen-permission is hidden by default and reports unknown instead of fail', async () => {
+    const visibleIds = getScanners().map(scanner => scanner.id);
+    const allIds = getScanners({ includeDefaultDisabled: true }).map(scanner => scanner.id);
+
+    expect(visibleIds).not.toContain('screen-permission');
+    expect(allIds).toContain('screen-permission');
+
+    const scanner = getScannerById('screen-permission');
+    expect(scanner).toBeDefined();
+
+    const result = await scanner!.scan();
+    expect(result.status).toBe('unknown');
+    expect(result.message).toContain('无法可靠检测');
+  });
+
+  it('proxy-config treats a valid proxy as pass instead of a warning', async () => {
+    _test.mockExecSync = (cmd: string) => {
+      if (cmd.includes('echo $HTTP_PROXY $HTTPS_PROXY')) {
+        return Buffer.from('http://127.0.0.1:7890\n');
+      }
+      throw commandError();
+    };
+
+    const scanner = getScannerById('proxy-config');
+    expect(scanner).toBeDefined();
+
+    const result = await scanner!.scan();
+    expect(result.status).toBe('pass');
+    expect(result.message).toContain('检测到代理配置');
+  });
+
+  it('dns-resolution no longer relies on google.com and downgrades partial failures to warn', async () => {
+    _test.mockExecSync = (cmd: string) => {
+      if (cmd.includes('nslookup github.com')) return Buffer.from('ok');
+      if (cmd.includes('nslookup registry.npmjs.org')) return Buffer.from('ok');
+      if (cmd.includes('nslookup pypi.org')) throw commandError(1);
+      throw commandError();
+    };
+
+    const scanner = getScannerById('dns-resolution');
+    expect(scanner).toBeDefined();
+
+    const result = await scanner!.scan();
+    expect(result.status).toBe('warn');
+    expect(result.message).toContain('DNS 解析异常');
+    expect(result.detail).toContain('pypi.org:FAIL');
+  });
+
+  it('ssl-certs downgrades partial HTTPS failures to warn', async () => {
+    _test.mockExecSync = (cmd: string) => {
+      if (cmd.includes('https://github.com')) return Buffer.from('200');
+      if (cmd.includes('https://registry.npmjs.org')) return Buffer.from('FAIL');
+      throw commandError();
+    };
+
+    const scanner = getScannerById('ssl-certs');
+    expect(scanner).toBeDefined();
+
+    const result = await scanner!.scan();
+    expect(result.status).toBe('warn');
+    expect(result.message).toContain('握手异常');
+    expect(result.detail).toContain('github.com: 200');
+  });
+});


### PR DESCRIPTION
## Summary
- fix multiple default-scan false positives and conflicting Apple Silicon/Rosetta checks
- stop default CLI scans from auto-uploading; keep local-only by default unless `--upload` is set
- expand repair coverage with dedicated fixers for git identity, uv, optional AI tools, and guidance-based network/credential/admin flows
- add risk-aware repair presentation in Web/CLI so green/yellow/red actions are visible and sorted by priority

## Key changes
- normalize official npm registry detection and avoid warning on `https://registry.npmjs.org`
- unify Apple Silicon / Rosetta detection through shared helpers
- hide screen-permission from default core checks and downgrade it to guidance-only unknown status
- treat valid proxy configuration as pass instead of misconfiguration
- downgrade DNS/SSL checks to no-score diagnostics and make partial network failures warn instead of fail
- add installer-backed fixers for `claude-code`, `openclaw`, `gemini-cli`, and `ccswitch`
- add guidance fixers for `git-credential-health`, `admin-perms`, `proxy-config`, `dns-resolution`, and `ssl-certs`

## Validation
- `npm run build`
- `npm test` (74 tests passed locally)
- `node dist/index.js --json`
- `node dist/index.js fix --dry-run`
