### PR TITLE
feat: route owner validation prompts by execution decision

### DIFF
--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -984,6 +984,12 @@ function buildReviewAutomationTarget(item: Record<string, unknown>) {
   } satisfies Record<string, unknown>;
 }
 
+function normalizeExecutionTargetFlag(value: unknown): boolean | null {
+  if (value === true) return true;
+  if (value === false) return false;
+  return null;
+}
+
 function serverAutomationMode(item: Record<string, unknown>) {
   const contract = item.automation_contract;
   if (contract && typeof contract === 'object') {
@@ -999,8 +1005,51 @@ function serverAutomationMode(item: Record<string, unknown>) {
   return 'manual_only';
 }
 
-function serverAutomationReady(item: Record<string, unknown>) {
-  return serverAutomationMode(item) === 'auto';
+function serverExecutionDecision(item: Record<string, unknown>, phase = 'owner_verification') {
+  const payload = item.execution_decision;
+  if (payload && typeof payload === 'object') {
+    const raw = payload as Record<string, unknown>;
+    const decision = String(raw.decision || '').trim();
+    if (decision) {
+      const targetRoute = raw.target_route && typeof raw.target_route === 'object'
+        ? raw.target_route as Record<string, unknown>
+        : {};
+      return {
+        phase: String(raw.phase || phase).trim() || phase,
+        decision,
+        reason_codes: Array.isArray(raw.reason_codes)
+          ? raw.reason_codes.map((value) => String(value || '').trim()).filter(Boolean)
+          : [],
+        current_profile_is_target: normalizeExecutionTargetFlag(raw.current_profile_is_target),
+        target_route: targetRoute,
+      };
+    }
+  }
+  return {
+    phase,
+    decision: serverAutomationMode(item) === 'auto' ? 'auto_validate' : 'manual_only',
+    reason_codes: [] as string[],
+    current_profile_is_target: null as boolean | null,
+    target_route: {} as Record<string, unknown>,
+  };
+}
+
+function serverAutomationReady(item: Record<string, unknown>, phase = 'owner_verification') {
+  return serverExecutionDecision(item, phase).decision === 'auto_validate';
+}
+
+function shouldPromptCurrentMachine(decision: ReturnType<typeof serverExecutionDecision>) {
+  return decision.phase === 'owner_verification' && decision.current_profile_is_target !== false;
+}
+
+function formatExecutionRoute(decision: ReturnType<typeof serverExecutionDecision>) {
+  const route = decision.target_route;
+  const parts = [
+    route.profile_id ? `profile=${String(route.profile_id)}` : '',
+    route.device_id ? `device=${String(route.device_id)}` : '',
+    route.agent_type ? `agent=${String(route.agent_type)}` : '',
+  ].filter(Boolean);
+  return parts.join(' / ');
 }
 
 function requiresStrictSubmissionAutoContract(item: Record<string, unknown>) {
@@ -1404,13 +1453,17 @@ async function processPendingReviewAssignments(headers: Record<string, string>) 
     const proofPayload = ((submissionRun.proof_payload as Record<string, unknown> | undefined) || {});
     const reviewTarget = buildReviewAutomationTarget(item);
     const localAutomation = buildValidationAutomationAssessment(reviewTarget);
+    const serverDecision = serverExecutionDecision(item, 'review_verification');
     if (!assignmentId || !localAutomation.selected_command) {
       process.stdout.write(`[Worker] review-auto 跳过 ${assignmentId || 'unknown'}: 无可自动执行的验证命令\n`);
       skipped++;
       continue;
     }
-    if (!serverAutomationReady(item)) {
-      process.stdout.write(`[Worker] review-auto 跳过 ${assignmentId}: 平台已标记为 manual-only\n`);
+    if (!serverAutomationReady(item, 'review_verification')) {
+      const label = serverDecision.decision === 'manual_only'
+        ? '平台已标记为 manual-only'
+        : `平台决策=${serverDecision.decision}`;
+      process.stdout.write(`[Worker] review-auto 跳过 ${assignmentId}: ${label}\n`);
       skipped++;
       continue;
     }
@@ -1480,18 +1533,40 @@ async function processPendingOwnerVerifications(headers: Record<string, string>,
     if (!bountyId || !answerId) { skipped++; continue; }
     const guideRecord = writeOwnerVerifyGuide(item, config);
     const localAutomation = buildValidationAutomationAssessment(item);
-    if (!localAutomation.selected_command) {
-      process.stdout.write(`[Worker] owner-auto 跳过 ${bountyId}/${answerId}: 无可自动执行的验证命令\n`);
+    const serverDecision = serverExecutionDecision(item, 'owner_verification');
+    const promptCurrentMachine = shouldPromptCurrentMachine(serverDecision);
+    const routeLabel = formatExecutionRoute(serverDecision);
+    if (serverDecision.decision === 'ask_user_run') {
+      if (promptCurrentMachine) {
+        process.stdout.write(
+          `[Worker] owner-prompt 待人工确认 ${bountyId}/${answerId}: ${guideRecord.guideMd}\n`,
+        );
+      } else {
+        process.stdout.write(
+          `[Worker] owner-auto 跳过 ${bountyId}/${answerId}: 已路由回原机器${routeLabel ? ` (${routeLabel})` : ''}\n`,
+        );
+      }
       skipped++;
       continue;
     }
-    if (!serverAutomationReady(item)) {
+    if (!localAutomation.selected_command) {
+      const message = promptCurrentMachine
+        ? `owner-prompt 待人工确认 ${bountyId}/${answerId}: 无可自动执行的验证命令，请查看 ${guideRecord.guideMd}`
+        : `owner-auto 跳过 ${bountyId}/${answerId}: 无可自动执行的验证命令`;
+      process.stdout.write(`[Worker] ${message}\n`);
+      skipped++;
+      continue;
+    }
+    if (!serverAutomationReady(item, 'owner_verification')) {
       process.stdout.write(`[Worker] owner-auto 跳过 ${bountyId}/${answerId}: 平台已标记为 manual-only\n`);
       skipped++;
       continue;
     }
     if (localAutomation.status !== 'ready') {
-      process.stdout.write(`[Worker] owner-auto 跳过 ${bountyId}/${answerId}: 本地未匹配到可自动执行的项目目录\n`);
+      const message = promptCurrentMachine
+        ? `owner-prompt 待人工确认 ${bountyId}/${answerId}: 本地未匹配到可自动执行的项目目录，请查看 ${guideRecord.guideMd}`
+        : `owner-auto 跳过 ${bountyId}/${answerId}: 本地未匹配到可自动执行的项目目录`;
+      process.stdout.write(`[Worker] ${message}\n`);
       skipped++;
       continue;
     }
@@ -1538,6 +1613,8 @@ function writeOwnerVerifyGuide(item: Record<string, unknown>, config: Record<str
   const suggestedValidationCmd = selectOwnerValidationCommand(item);
   const workdirMatch = resolveValidationWorkdir(item);
   const suggestedProjectDir = String(workdirMatch?.cwd || '').trim();
+  const executionDecision = serverExecutionDecision(item, 'owner_verification');
+  const targetRoute = formatExecutionRoute(executionDecision);
   const verifyCommand = `mac-aicheck agent owner-verify ${item.bounty_id} --answer ${item.answer_id} --result success|partial|failed --cmd "<local validation command>"`;
   const lines = [
     '# AICOEVO 发起者复现指南',
@@ -1552,6 +1629,7 @@ function writeOwnerVerifyGuide(item: Record<string, unknown>, config: Record<str
     '',
     item.solution_summary || '暂无方案摘要。',
     '',
+    ...(targetRoute ? ['## 目标机器', '', targetRoute, ''] : []),
     ...(suggestedProjectDir ? ['## 建议项目目录', '', `\`${suggestedProjectDir}\``, ''] : []),
     ...(suggestedValidationCmd ? ['## 推荐验证命令', '', `\`${suggestedValidationCmd}\``, ''] : []),
     ...(item.expected_output ? ['## 期望结果', '', String(item.expected_output), ''] : []),
@@ -1580,6 +1658,7 @@ function writeOwnerVerifyGuide(item: Record<string, unknown>, config: Record<str
     expectedOutput: String(item.expected_output || ''),
     suggestedProjectDir,
     projectHint: validationProjectHint(item),
+    executionDecision,
   };
   writeJson(files.snapshotJson, snapshot);
   return {
@@ -3053,6 +3132,8 @@ export async function main(argv: string[]) {
       for (const item of pending) {
         const guide = writeOwnerVerifyGuide(item, cfg);
         const automation = buildValidationAutomationAssessment(item);
+        const decision = serverExecutionDecision(item, 'owner_verification');
+        const routeLabel = formatExecutionRoute(decision);
         process.stdout.write(`## ${item.title || '(无标题)'}\n`);
         process.stdout.write(`  Bounty:   ${item.bounty_id}\n`);
         process.stdout.write(`  Answer:   ${item.answer_id}\n`);
@@ -3063,6 +3144,10 @@ export async function main(argv: string[]) {
         if ((guide.snapshot as Record<string, unknown> | null)?.suggestedProjectDir) {
           process.stdout.write(`  项目目录: ${String((guide.snapshot as Record<string, unknown>).suggestedProjectDir)}\n`);
         }
+        process.stdout.write(`  执行决策: ${decision.decision}\n`);
+        if (routeLabel) process.stdout.write(`  目标机器: ${routeLabel}\n`);
+        if (decision.current_profile_is_target === true) process.stdout.write('  当前机器: 目标机器\n');
+        if (decision.current_profile_is_target === false) process.stdout.write('  当前机器: 非目标机器\n');
         process.stdout.write(`  自动验证: ${automation.status}\n`);
         if (automation.selected_command) process.stdout.write(`  自动命令: ${automation.selected_command}\n`);
         if (automation.suggested_project_dir) process.stdout.write(`  自动目录: ${automation.suggested_project_dir}\n`);

--- a/tests/agent-v2-flow.test.ts
+++ b/tests/agent-v2-flow.test.ts
@@ -232,6 +232,16 @@ describe('agent v2 flow', () => {
           solution_summary: 'Run npm cache clean --force',
           submitted_at: '2026-04-26T00:00:00Z',
           deadline_at: '2026-04-28T00:00:00Z',
+          execution_decision: {
+            decision: 'ask_user_run',
+            phase: 'owner_verification',
+            current_profile_is_target: true,
+            target_route: {
+              profile_id: 'prof_001',
+              device_id: 'device_001',
+              agent_type: 'claude-code',
+            },
+          },
         }],
         timestamp: '2026-04-26T00:00:00Z',
       }),
@@ -250,6 +260,8 @@ describe('agent v2 flow', () => {
     expect(output).toContain('a_001');
     expect(output).toContain('npm install fails');
     expect(output).toContain('owner-verify');
+    expect(output).toContain('执行决策: ask_user_run');
+    expect(output).toContain('目标机器: profile=prof_001 / device=device_001 / agent=claude-code');
     expect(output).toContain('自动验证: blocked');
     expect(output).toContain('阻塞原因: missing_validation_command');
     const guidePath = path.join(home, '.mac-aicheck', 'owner-verify', 'b_001__a_001.md');
@@ -1089,6 +1101,64 @@ describe('worker-on (TASK-091)', () => {
     const body = JSON.parse(requests[3]?.body || '{}');
     expect(body.artifacts.owner_reproduction_project_dir).toBe(projectRoot);
     expect(body.proof_payload.after_context.local_context.project_dir).toBe(projectRoot);
+  });
+
+  it('worker daemon writes owner prompt when platform routes execution back to the origin machine', async () => {
+    seedConfig();
+    const requests: string[] = [];
+    let fetchCount = 0;
+    const fetchMock = vi.fn().mockImplementation(async (url: string) => {
+      requests.push(url);
+      fetchCount++;
+      if (fetchCount >= 2) {
+        const cfg = _testHelpers.loadConfig();
+        cfg.workerEnabled = false;
+        _testHelpers.saveConfig(cfg);
+      }
+      if (url.includes('/heartbeat')) return mockResponse({ recommended_bounties: [] });
+      if (url.includes('/status')) {
+        return mockResponse({
+          pending_owner_verifications: [{
+            bounty_id: 'b_owner_prompt',
+            answer_id: 'a_owner_prompt',
+            title: 'prompt owner on origin machine',
+            solution_summary: 'Please verify on the original machine',
+            submitted_at: '2026-04-30T00:00:00Z',
+            deadline_at: '2026-05-02T00:00:00Z',
+            execution_decision: {
+              decision: 'ask_user_run',
+              phase: 'owner_verification',
+              current_profile_is_target: true,
+              target_route: {
+                profile_id: 'prof-owner',
+                device_id: 'device-owner',
+                agent_type: 'claude-code',
+              },
+            },
+          }],
+        });
+      }
+      return mockResponse({});
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    const execSpy = vi.fn();
+    (globalThis as {
+      __MAC_AICHECK_TEST_EXEC__?: (command: string) => { exitCode: number; stdout?: string; stderr?: string };
+    }).__MAC_AICHECK_TEST_EXEC__ = (command: string) => {
+      execSpy(command);
+      return { exitCode: 0, stdout: '', stderr: '' };
+    };
+
+    const capture = captureOutput();
+    const code = await agentMain(['worker', 'daemon', '--worker-interval', '10']);
+    capture.spy.mockRestore();
+
+    expect(code).toBe(0);
+    expect(execSpy).not.toHaveBeenCalled();
+    expect(requests.some(url => url.includes('/owner-verify'))).toBe(false);
+    expect(capture.output).toContain('owner-prompt 待人工确认 b_owner_prompt/a_owner_prompt');
+    const wState = _testHelpers.loadWorkerState();
+    expect(wState.totalOwnerSkipped).toBeGreaterThanOrEqual(1);
   });
 
   it('worker daemon skips owner verification when only unsafe commands are available', async () => {


### PR DESCRIPTION
## Summary
- consume platform `execution_decision` payload for owner/reviewer validation loops
- auto-run only when the platform says `auto_validate` and local safety gates still pass
- write origin-machine owner prompts/guides when the platform routes work back for manual confirmation

## Verification
- `npm test -- tests/agent-v2-flow.test.ts`
- `npm run build`

## Notes
- `npm test` full suite still has an unrelated pre-existing failure in `tests/fixers.test.ts`