### PR TITLE
feat: gate owner auto validation with prepare task

### DIFF
--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -1038,6 +1038,36 @@ function serverAutomationReady(item: Record<string, unknown>, phase = 'owner_ver
   return serverExecutionDecision(item, phase).decision === 'auto_validate';
 }
 
+async function prepareOwnerValidationTask(headers: Record<string, string>, answerId: string) {
+  return requestJson(`${agentApiBase('v2')}/owner-validation-tasks/prepare`, {
+    method: 'POST',
+    headers,
+    body: { answer_id: answerId },
+  });
+}
+
+function ownerValidationGateDetails(payload: unknown) {
+  const data = payload && typeof payload === 'object'
+    ? payload as Record<string, unknown>
+    : {};
+  const prepareState = data.prepare_state && typeof data.prepare_state === 'object'
+    ? data.prepare_state as Record<string, unknown>
+    : {};
+  const userAuthorizationGate = data.user_authorization_gate && typeof data.user_authorization_gate === 'object'
+    ? data.user_authorization_gate as Record<string, unknown>
+    : {};
+  const webConfirmation = data.web_confirmation && typeof data.web_confirmation === 'object'
+    ? data.web_confirmation as Record<string, unknown>
+    : {};
+  return {
+    prepared: data.prepared === true || prepareState.prepared === true,
+    prepared_action: String(data.prepared_action || prepareState.prepared_action || '').trim(),
+    prepare_state: prepareState,
+    user_authorization_gate: userAuthorizationGate,
+    web_confirmation: webConfirmation,
+  };
+}
+
 function shouldPromptCurrentMachine(decision: ReturnType<typeof serverExecutionDecision>) {
   return decision.phase === 'owner_verification' && decision.current_profile_is_target !== false;
 }
@@ -1567,6 +1597,26 @@ async function processPendingOwnerVerifications(headers: Record<string, string>,
         ? `owner-prompt 待人工确认 ${bountyId}/${answerId}: 本地未匹配到可自动执行的项目目录，请查看 ${guideRecord.guideMd}`
         : `owner-auto 跳过 ${bountyId}/${answerId}: 本地未匹配到可自动执行的项目目录`;
       process.stdout.write(`[Worker] ${message}\n`);
+      skipped++;
+      continue;
+    }
+    const prepareResult = await prepareOwnerValidationTask(headers, answerId);
+    if (prepareResult.status !== 200) {
+      process.stdout.write(`[Worker] owner-auto 跳过 ${bountyId}/${answerId}: 平台 prepare 失败 (${prepareResult.status})\n`);
+      skipped++;
+      continue;
+    }
+    const prepareGate = ownerValidationGateDetails(prepareResult.data);
+    if (!prepareGate.prepared) {
+      if (prepareGate.prepared_action === 'confirm_on_web_then_run') {
+        process.stdout.write(
+          `[Worker] owner-auto 跳过 ${bountyId}/${answerId}: 需要先在网站确认后再运行，请先到 AICOEVO 网站确认并查看 ${guideRecord.guideMd}\n`,
+        );
+      } else {
+        process.stdout.write(
+          `[Worker] owner-auto 跳过 ${bountyId}/${answerId}: 平台未放行自动执行，请按指南人工确认 ${guideRecord.guideMd}\n`,
+        );
+      }
       skipped++;
       continue;
     }
@@ -3134,6 +3184,7 @@ export async function main(argv: string[]) {
         const automation = buildValidationAutomationAssessment(item);
         const decision = serverExecutionDecision(item, 'owner_verification');
         const routeLabel = formatExecutionRoute(decision);
+        const gate = ownerValidationGateDetails(item);
         process.stdout.write(`## ${item.title || '(无标题)'}\n`);
         process.stdout.write(`  Bounty:   ${item.bounty_id}\n`);
         process.stdout.write(`  Answer:   ${item.answer_id}\n`);
@@ -3149,6 +3200,20 @@ export async function main(argv: string[]) {
         if (decision.current_profile_is_target === true) process.stdout.write('  当前机器: 目标机器\n');
         if (decision.current_profile_is_target === false) process.stdout.write('  当前机器: 非目标机器\n');
         process.stdout.write(`  自动验证: ${automation.status}\n`);
+        if (gate.prepared_action) process.stdout.write(`  平台放行: ${gate.prepared_action}\n`);
+        if (
+          Object.prototype.hasOwnProperty.call(gate.user_authorization_gate, 'allow_safe_validation_autorun')
+        ) {
+          process.stdout.write(
+            `  自动运行授权: ${gate.user_authorization_gate.allow_safe_validation_autorun === true ? '已开启' : '未开启'}\n`,
+          );
+        }
+        if (
+          Object.prototype.hasOwnProperty.call(gate.user_authorization_gate, 'require_web_confirmation_for_validation')
+          || Object.keys(gate.web_confirmation).length > 0
+        ) {
+          process.stdout.write(`  网站确认: ${gate.web_confirmation.confirmed === true ? '已确认' : '待确认'}\n`);
+        }
         if (automation.selected_command) process.stdout.write(`  自动命令: ${automation.selected_command}\n`);
         if (automation.suggested_project_dir) process.stdout.write(`  自动目录: ${automation.suggested_project_dir}\n`);
         if (automation.blocking_reasons.length > 0) process.stdout.write(`  阻塞原因: ${automation.blocking_reasons.join(', ')}\n`);

--- a/tests/agent-v2-flow.test.ts
+++ b/tests/agent-v2-flow.test.ts
@@ -242,6 +242,17 @@ describe('agent v2 flow', () => {
               agent_type: 'claude-code',
             },
           },
+          user_authorization_gate: {
+            allow_safe_validation_autorun: false,
+            require_web_confirmation_for_validation: true,
+          },
+          web_confirmation: {
+            confirmed: false,
+          },
+          prepare_state: {
+            prepared: false,
+            prepared_action: 'manual_confirm_only',
+          },
         }],
         timestamp: '2026-04-26T00:00:00Z',
       }),
@@ -263,6 +274,9 @@ describe('agent v2 flow', () => {
     expect(output).toContain('执行决策: ask_user_run');
     expect(output).toContain('目标机器: profile=prof_001 / device=device_001 / agent=claude-code');
     expect(output).toContain('自动验证: blocked');
+    expect(output).toContain('平台放行: manual_confirm_only');
+    expect(output).toContain('自动运行授权: 未开启');
+    expect(output).toContain('网站确认: 待确认');
     expect(output).toContain('阻塞原因: missing_validation_command');
     const guidePath = path.join(home, '.mac-aicheck', 'owner-verify', 'b_001__a_001.md');
     const snapshotPath = path.join(home, '.mac-aicheck', 'owner-verify', 'b_001__a_001.json');
@@ -911,6 +925,13 @@ describe('worker-on (TASK-091)', () => {
           }],
         });
       }
+      if (url.includes('/owner-validation-tasks/prepare')) {
+        return mockResponse({
+          prepared: true,
+          prepared_action: 'run_validation_now',
+          prepare_state: { prepared: true, prepared_action: 'run_validation_now' },
+        });
+      }
       if (url.includes('/owner-verify')) return mockResponse({ review_status: 'pending_review', owner_score: 60, total_score: 60, threshold: 70 });
       return mockResponse({});
     });
@@ -931,8 +952,11 @@ describe('worker-on (TASK-091)', () => {
     expect(requests[0]?.url).toContain('/heartbeat');
     expect(requests[1]?.url).toContain('/reviews/recommended');
     expect(requests[2]?.url).toContain('/status');
-    expect(requests[3]?.url).toContain('/owner-verify');
-    const body = JSON.parse(requests[3]?.body || '{}');
+    expect(requests[3]?.url).toContain('/owner-validation-tasks/prepare');
+    expect(requests[4]?.url).toContain('/owner-verify');
+    const prepareBody = JSON.parse(requests[3]?.body || '{}');
+    expect(prepareBody.answer_id).toBe('a_owner_1');
+    const body = JSON.parse(requests[4]?.body || '{}');
     expect(body.result).toBe('success');
     expect(body.commands_run).toEqual(['pytest -q']);
     expect(body.proof_payload.validation_cmd).toBe('pytest -q');
@@ -1080,6 +1104,13 @@ describe('worker-on (TASK-091)', () => {
           }],
         });
       }
+      if (url.includes('/owner-validation-tasks/prepare')) {
+        return mockResponse({
+          prepared: true,
+          prepared_action: 'run_validation_now',
+          prepare_state: { prepared: true, prepared_action: 'run_validation_now' },
+        });
+      }
       if (url.includes('/owner-verify')) return mockResponse({ review_status: 'pending_review', owner_score: 60, total_score: 60, threshold: 70 });
       return mockResponse({});
     });
@@ -1097,10 +1128,178 @@ describe('worker-on (TASK-091)', () => {
     spy.mockRestore();
 
     expect(code).toBe(0);
-    expect(requests[3]?.url).toContain('/owner-verify');
-    const body = JSON.parse(requests[3]?.body || '{}');
+    expect(requests[3]?.url).toContain('/owner-validation-tasks/prepare');
+    expect(requests[4]?.url).toContain('/owner-verify');
+    const body = JSON.parse(requests[4]?.body || '{}');
     expect(body.artifacts.owner_reproduction_project_dir).toBe(projectRoot);
     expect(body.proof_payload.after_context.local_context.project_dir).toBe(projectRoot);
+  });
+
+  it('worker daemon waits for website confirmation before owner auto validation', async () => {
+    const home = seedConfig();
+    const projectRoot = path.join(home, 'demo-owner-web-confirm-project');
+    mkdirSync(path.join(projectRoot, 'tests'), { recursive: true });
+    writeFileSync(path.join(projectRoot, 'pyproject.toml'), '[project]\nname="demo-owner-web-confirm"\n', 'utf8');
+    const outboxPath = path.join(home, '.mac-aicheck', 'outbox', 'events.jsonl');
+    mkdirSync(path.dirname(outboxPath), { recursive: true });
+    writeFileSync(outboxPath, `${JSON.stringify({
+      eventId: 'evt_owner_web_gate_1',
+      deviceId: 'device-test_cc',
+      agent: 'claude-code',
+      fingerprint: 'fp_owner_web_gate',
+      eventType: 'post_tool_error',
+      occurredAt: '2026-04-30T00:00:00Z',
+      sanitizedMessage: 'pytest failed before web confirm',
+      toolContext: { cwd: projectRoot, command: 'pytest -q' },
+    })}\n`, 'utf8');
+    const requests: string[] = [];
+    let fetchCount = 0;
+    const fetchMock = vi.fn().mockImplementation(async (url: string) => {
+      requests.push(url);
+      fetchCount++;
+      if (fetchCount >= 3) {
+        const cfg = _testHelpers.loadConfig();
+        cfg.workerEnabled = false;
+        _testHelpers.saveConfig(cfg);
+      }
+      if (url.includes('/heartbeat')) return mockResponse({ recommended_bounties: [] });
+      if (url.includes('/status')) {
+        return mockResponse({
+          pending_owner_verifications: [{
+            bounty_id: 'b_owner_web_gate',
+            answer_id: 'a_owner_web_gate',
+            title: 'owner web confirmation required',
+            solution_summary: 'Run tests again',
+            submitted_at: '2026-04-30T00:00:00Z',
+            deadline_at: '2026-05-02T00:00:00Z',
+            validation_cmd: 'pytest -q',
+            commands_run: ['pytest -q'],
+            project_hint: {
+              fingerprint: 'fp_owner_web_gate',
+              event_type: 'post_tool_error',
+              cwd_hash: '',
+              origin_agent_type: 'claude-code',
+              tool_context: { command: 'pytest -q' },
+            },
+            automation_contract: { mode: 'auto', auto_run_allowed: true },
+            automation_readiness: { status: 'ready', selected_command: 'pytest -q' },
+          }],
+        });
+      }
+      if (url.includes('/owner-validation-tasks/prepare')) {
+        return mockResponse({
+          prepared: false,
+          prepared_action: 'confirm_on_web_then_run',
+          prepare_state: {
+            prepared: false,
+            prepared_action: 'confirm_on_web_then_run',
+            web_confirmation_required: true,
+            web_confirmation_recorded: false,
+          },
+        });
+      }
+      return mockResponse({});
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    const execSpy = vi.fn();
+    (globalThis as {
+      __MAC_AICHECK_TEST_EXEC__?: (command: string) => { exitCode: number; stdout?: string; stderr?: string };
+    }).__MAC_AICHECK_TEST_EXEC__ = (command: string) => {
+      execSpy(command);
+      return { exitCode: 0, stdout: '', stderr: '' };
+    };
+
+    const capture = captureOutput();
+    const code = await agentMain(['worker', 'daemon', '--worker-interval', '10']);
+    capture.spy.mockRestore();
+
+    expect(code).toBe(0);
+    expect(execSpy).not.toHaveBeenCalled();
+    expect(requests.some(url => url.includes('/owner-validation-tasks/prepare'))).toBe(true);
+    expect(requests.some(url => url.includes('/owner-verify'))).toBe(false);
+    expect(capture.output).toContain('需要先在网站确认后再运行');
+  });
+
+  it('worker daemon skips owner auto validation when platform prepare stays manual only', async () => {
+    const home = seedConfig();
+    const projectRoot = path.join(home, 'demo-owner-prepare-manual-project');
+    mkdirSync(path.join(projectRoot, 'tests'), { recursive: true });
+    writeFileSync(path.join(projectRoot, 'pyproject.toml'), '[project]\nname="demo-owner-manual"\n', 'utf8');
+    const outboxPath = path.join(home, '.mac-aicheck', 'outbox', 'events.jsonl');
+    mkdirSync(path.dirname(outboxPath), { recursive: true });
+    writeFileSync(outboxPath, `${JSON.stringify({
+      eventId: 'evt_owner_prepare_manual_1',
+      deviceId: 'device-test_cc',
+      agent: 'claude-code',
+      fingerprint: 'fp_owner_prepare_manual',
+      eventType: 'post_tool_error',
+      occurredAt: '2026-04-30T00:00:00Z',
+      sanitizedMessage: 'pytest failed before prepare manual',
+      toolContext: { cwd: projectRoot, command: 'pytest -q' },
+    })}\n`, 'utf8');
+    const requests: string[] = [];
+    let fetchCount = 0;
+    const fetchMock = vi.fn().mockImplementation(async (url: string) => {
+      requests.push(url);
+      fetchCount++;
+      if (fetchCount >= 3) {
+        const cfg = _testHelpers.loadConfig();
+        cfg.workerEnabled = false;
+        _testHelpers.saveConfig(cfg);
+      }
+      if (url.includes('/heartbeat')) return mockResponse({ recommended_bounties: [] });
+      if (url.includes('/status')) {
+        return mockResponse({
+          pending_owner_verifications: [{
+            bounty_id: 'b_owner_prepare_manual',
+            answer_id: 'a_owner_prepare_manual',
+            title: 'owner prepare manual only',
+            solution_summary: 'Run tests again',
+            submitted_at: '2026-04-30T00:00:00Z',
+            deadline_at: '2026-05-02T00:00:00Z',
+            validation_cmd: 'pytest -q',
+            commands_run: ['pytest -q'],
+            project_hint: {
+              fingerprint: 'fp_owner_prepare_manual',
+              event_type: 'post_tool_error',
+              origin_agent_type: 'claude-code',
+              tool_context: { command: 'pytest -q' },
+            },
+            automation_contract: { mode: 'auto', auto_run_allowed: true },
+            automation_readiness: { status: 'ready', selected_command: 'pytest -q' },
+          }],
+        });
+      }
+      if (url.includes('/owner-validation-tasks/prepare')) {
+        return mockResponse({
+          prepared: false,
+          prepared_action: 'manual_confirm_only',
+          prepare_state: {
+            prepared: false,
+            prepared_action: 'manual_confirm_only',
+          },
+        });
+      }
+      return mockResponse({});
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    const execSpy = vi.fn();
+    (globalThis as {
+      __MAC_AICHECK_TEST_EXEC__?: (command: string) => { exitCode: number; stdout?: string; stderr?: string };
+    }).__MAC_AICHECK_TEST_EXEC__ = (command: string) => {
+      execSpy(command);
+      return { exitCode: 0, stdout: '', stderr: '' };
+    };
+
+    const capture = captureOutput();
+    const code = await agentMain(['worker', 'daemon', '--worker-interval', '10']);
+    capture.spy.mockRestore();
+
+    expect(code).toBe(0);
+    expect(execSpy).not.toHaveBeenCalled();
+    expect(requests.some(url => url.includes('/owner-validation-tasks/prepare'))).toBe(true);
+    expect(requests.some(url => url.includes('/owner-verify'))).toBe(false);
+    expect(capture.output).toContain('平台未放行自动执行');
   });
 
   it('worker daemon writes owner prompt when platform routes execution back to the origin machine', async () => {


### PR DESCRIPTION
## Summary
- call platform prepare API before any owner auto validation execution
- stop local auto-run when platform requires website confirmation or manual-only handling
- show platform gate, authorization and website confirmation status in owner-check output

## Verification
- npm test -- --run tests/agent-v2-flow.test.ts

## Notes
- phase remains machine-origin only
- website confirmation stays JWT-only on platform; client only prompts the user to confirm on web