### PR TITLE
TASK-190: block Mac owner_repair before rollback parity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes will be documented in this file.
 
+## [1.0.7] - 2026-05-02
+
+### Changed
+
+- Agent Protocol V2 现已在 MacAICheck 中解析 `lifecycle_state`、`risk_level`、`execution_task.kind`、`repair_capability`、`consent_state`、`rollback_state`、`prepare_state`。
+- Mac worker 保持 P0 安全边界：继续支持 L0/L1 owner validation 自动验证，但在缺少 backup/rollback parity 时显式阻断 `owner_repair`，返回 `blocked_pending_rollback_parity`，且不会触发本地执行或 owner verify 提交。
+
 ## [1.0.0] - 2026-04-06
 
 ### 首次发布

--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ bash scripts/openclaw-smoke.sh
 - Claude Code 使用 `~/.claude/settings.json` 的 SessionStart/PostToolUse hooks。
 - OpenClaw 使用 shell hook 写入 `~/.zshrc` / `~/.bashrc` / `~/.bash_profile`。
 - 悬赏命令需要先运行 `mac-aicheck agent bind` 获取 Agent API Key。
+- Agent Protocol V2 的 P0 自动验证范围仅包含 owner validation（L0/L1）；当平台下发 `execution_task.kind=owner_repair` 且仍缺少 macOS rollback parity 时，MacAICheck 会显式阻断并返回 `blocked_pending_rollback_parity`，不会自动执行本地修复。
 
 ### 上报数据格式
 

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -1068,6 +1068,51 @@ function ownerValidationGateDetails(payload: unknown) {
   };
 }
 
+function ownerTaskPhaseDetails(payload: unknown) {
+  const data = payload && typeof payload === 'object'
+    ? payload as Record<string, unknown>
+    : {};
+  const executionTask = data.execution_task && typeof data.execution_task === 'object'
+    ? data.execution_task as Record<string, unknown>
+    : {};
+  const repairCapability = data.repair_capability && typeof data.repair_capability === 'object'
+    ? data.repair_capability as Record<string, unknown>
+    : {};
+  const consentState = data.consent_state && typeof data.consent_state === 'object'
+    ? data.consent_state as Record<string, unknown>
+    : {};
+  const rollbackState = data.rollback_state && typeof data.rollback_state === 'object'
+    ? data.rollback_state as Record<string, unknown>
+    : {};
+  const prepareState = data.prepare_state && typeof data.prepare_state === 'object'
+    ? data.prepare_state as Record<string, unknown>
+    : {};
+  const lifecycleState = String(data.lifecycle_state || '').trim();
+  const riskLevel = String(data.risk_level || '').trim();
+  const executionTaskKind = String(executionTask.kind || '').trim();
+  const repairCapabilityMode = String(repairCapability.mode || '').trim();
+  const consentStatus = String(consentState.status || '').trim();
+  const rollbackStatus = String(rollbackState.status || '').trim();
+  const prepareStatus = String(prepareState.status || '').trim();
+  const requiresRollbackParityBlock = executionTaskKind === 'owner_repair';
+  return {
+    lifecycle_state: lifecycleState,
+    risk_level: riskLevel,
+    execution_task: executionTask,
+    execution_task_kind: executionTaskKind,
+    repair_capability: repairCapability,
+    repair_capability_mode: repairCapabilityMode,
+    consent_state: consentState,
+    consent_status: consentStatus,
+    rollback_state: rollbackState,
+    rollback_status: rollbackStatus,
+    prepare_state: prepareState,
+    prepare_status: prepareStatus,
+    requires_rollback_parity_block: requiresRollbackParityBlock,
+    block_reason: requiresRollbackParityBlock ? 'blocked_pending_rollback_parity' : '',
+  };
+}
+
 function shouldPromptCurrentMachine(decision: ReturnType<typeof serverExecutionDecision>) {
   return decision.phase === 'owner_verification' && decision.current_profile_is_target !== false;
 }
@@ -1563,9 +1608,18 @@ async function processPendingOwnerVerifications(headers: Record<string, string>,
     if (!bountyId || !answerId) { skipped++; continue; }
     const guideRecord = writeOwnerVerifyGuide(item, config);
     const localAutomation = buildValidationAutomationAssessment(item);
+    const phaseDetails = ownerTaskPhaseDetails(item);
     const serverDecision = serverExecutionDecision(item, 'owner_verification');
     const promptCurrentMachine = shouldPromptCurrentMachine(serverDecision);
     const routeLabel = formatExecutionRoute(serverDecision);
+    if (phaseDetails.requires_rollback_parity_block) {
+      const reason = phaseDetails.block_reason || 'blocked_pending_rollback_parity';
+      process.stdout.write(
+        `[Worker] owner-auto 跳过 ${bountyId}/${answerId}: ${reason} (task=${phaseDetails.execution_task_kind || 'unknown'}, risk=${phaseDetails.risk_level || 'unknown'})\n`,
+      );
+      skipped++;
+      continue;
+    }
     if (serverDecision.decision === 'ask_user_run') {
       if (promptCurrentMachine) {
         process.stdout.write(
@@ -3185,6 +3239,7 @@ export async function main(argv: string[]) {
         const decision = serverExecutionDecision(item, 'owner_verification');
         const routeLabel = formatExecutionRoute(decision);
         const gate = ownerValidationGateDetails(item);
+        const phaseDetails = ownerTaskPhaseDetails(item);
         process.stdout.write(`## ${item.title || '(无标题)'}\n`);
         process.stdout.write(`  Bounty:   ${item.bounty_id}\n`);
         process.stdout.write(`  Answer:   ${item.answer_id}\n`);
@@ -3192,6 +3247,13 @@ export async function main(argv: string[]) {
         process.stdout.write(`  提交时间: ${item.submitted_at}\n`);
         process.stdout.write(`  截止时间: ${item.deadline_at}\n\n`);
         if (item.validation_cmd) process.stdout.write(`  验证命令: ${item.validation_cmd}\n`);
+        if (phaseDetails.lifecycle_state) process.stdout.write(`  生命周期: ${phaseDetails.lifecycle_state}\n`);
+        if (phaseDetails.risk_level) process.stdout.write(`  风险等级: ${phaseDetails.risk_level}\n`);
+        if (phaseDetails.execution_task_kind) process.stdout.write(`  执行任务: ${phaseDetails.execution_task_kind}\n`);
+        if (phaseDetails.repair_capability_mode) process.stdout.write(`  修复能力: ${phaseDetails.repair_capability_mode}\n`);
+        if (phaseDetails.consent_status) process.stdout.write(`  授权状态: ${phaseDetails.consent_status}\n`);
+        if (phaseDetails.rollback_status) process.stdout.write(`  回滚状态: ${phaseDetails.rollback_status}\n`);
+        if (phaseDetails.prepare_status) process.stdout.write(`  准备状态: ${phaseDetails.prepare_status}\n`);
         if ((guide.snapshot as Record<string, unknown> | null)?.suggestedProjectDir) {
           process.stdout.write(`  项目目录: ${String((guide.snapshot as Record<string, unknown>).suggestedProjectDir)}\n`);
         }
@@ -3216,6 +3278,7 @@ export async function main(argv: string[]) {
         }
         if (automation.selected_command) process.stdout.write(`  自动命令: ${automation.selected_command}\n`);
         if (automation.suggested_project_dir) process.stdout.write(`  自动目录: ${automation.suggested_project_dir}\n`);
+        if (phaseDetails.block_reason) process.stdout.write(`  协议阻塞: ${phaseDetails.block_reason}\n`);
         if (automation.blocking_reasons.length > 0) process.stdout.write(`  阻塞原因: ${automation.blocking_reasons.join(', ')}\n`);
         if (automation.warning_reasons.length > 0) process.stdout.write(`  注意事项: ${automation.warning_reasons.join(', ')}\n`);
         process.stdout.write(`  指南:     ${guide.guideMd}\n`);
@@ -3317,6 +3380,7 @@ export const _testHelpers = {
   loadDraftOrganizerState,
   saveDraftOrganizerState,
   runDraftOrganizerOnce,
+  ownerTaskPhaseDetails,
 };
 
 if (require.main === module) {

--- a/tests/agent-v2-flow.test.ts
+++ b/tests/agent-v2-flow.test.ts
@@ -1514,6 +1514,104 @@ describe('worker-on (TASK-091)', () => {
     expect(capture.output).toContain('平台已标记为 manual-only');
   });
 
+  it('worker daemon blocks owner_repair tasks until rollback parity is implemented', async () => {
+    const home = seedConfig();
+    const projectDir = path.join(home, 'repo');
+    mkdirSync(projectDir, { recursive: true });
+    writeFileSync(path.join(projectDir, 'package.json'), JSON.stringify({ name: 'owner-repair-fixture' }), 'utf8');
+    const outboxPath = path.join(home, '.mac-aicheck', 'outbox', 'events.jsonl');
+    mkdirSync(path.dirname(outboxPath), { recursive: true });
+    writeFileSync(
+      outboxPath,
+      JSON.stringify({
+        fingerprint: 'fp_owner_repair_block_1',
+        eventType: 'post_tool_error',
+        agent: 'claude-code',
+        deviceId: 'device-test',
+        occurredAt: '2026-05-01T00:00:00Z',
+        toolContext: {
+          command: 'npm test',
+          filePath: path.join(projectDir, 'package.json'),
+          fileName: 'package.json',
+          cwd: projectDir,
+        },
+        localContext: {
+          cwdHash: 'cwdhash-owner-repair-block-1',
+        },
+      }) + '\n',
+      'utf8',
+    );
+
+    const requests: string[] = [];
+    let fetchCount = 0;
+    const fetchMock = vi.fn().mockImplementation(async (url: string) => {
+      requests.push(url);
+      fetchCount++;
+      if (fetchCount >= 2) {
+        const cfg = _testHelpers.loadConfig();
+        cfg.workerEnabled = false;
+        _testHelpers.saveConfig(cfg);
+      }
+      if (url.includes('/heartbeat')) return mockResponse({ recommended_bounties: [] });
+      if (url.includes('/status')) {
+        return mockResponse({
+          pending_owner_verifications: [{
+            bounty_id: 'b_owner_repair_block',
+            answer_id: 'a_owner_repair_block',
+            title: 'block owner repair before parity',
+            solution_summary: 'Validation command: npm test',
+            submitted_at: '2026-05-01T00:00:00Z',
+            deadline_at: '2026-05-03T00:00:00Z',
+            validation_cmd: 'npm test',
+            commands_run: ['npm test'],
+            lifecycle_state: 'awaiting_owner',
+            risk_level: 'L2',
+            execution_task: { kind: 'owner_repair' },
+            repair_capability: { available: false, mode: 'blocked' },
+            consent_state: { status: 'granted' },
+            rollback_state: { status: 'missing' },
+            prepare_state: { prepared: true, prepared_action: 'run_validation_now' },
+            automation_contract: { mode: 'auto', auto_run_allowed: true },
+            automation_readiness: {
+              status: 'ready',
+              selected_command: 'npm test',
+            },
+            project_hint: {
+              fingerprint: 'fp_owner_repair_block_1',
+              event_type: 'post_tool_error',
+              cwd_hash: 'cwdhash-owner-repair-block-1',
+              origin_device_id: 'device-test',
+              origin_agent_type: 'claude-code',
+              tool_context: {
+                command: 'npm test',
+                fileName: 'package.json',
+              },
+            },
+          }],
+        });
+      }
+      return mockResponse({});
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    const execSpy = vi.fn();
+    (globalThis as {
+      __MAC_AICHECK_TEST_EXEC__?: (command: string) => { exitCode: number; stdout?: string; stderr?: string };
+    }).__MAC_AICHECK_TEST_EXEC__ = (command: string) => {
+      execSpy(command);
+      return { exitCode: 0, stdout: '1 passed', stderr: '' };
+    };
+
+    const capture = captureOutput();
+    const code = await agentMain(['worker', 'daemon', '--worker-interval', '10']);
+    capture.spy.mockRestore();
+
+    expect(code).toBe(0);
+    expect(execSpy).not.toHaveBeenCalled();
+    expect(requests.some(url => url.includes('/owner-validation-tasks/prepare'))).toBe(false);
+    expect(requests.some(url => url.includes('/owner-verify'))).toBe(false);
+    expect(capture.output).toContain('blocked_pending_rollback_parity');
+  });
+
   it('worker daemon skips reviewer verification when command is safe but not a real validation', async () => {
     seedConfig();
     const requests: Array<{ url: string; body?: string }> = [];

--- a/tests/aicoevo-contract.test.ts
+++ b/tests/aicoevo-contract.test.ts
@@ -36,6 +36,28 @@ describe('AICOEVO contract alignment', () => {
     expect(_testHelpers.agentApiBase('v1')).toBe('https://aicoevo.net/api/v1/agent');
   });
 
+  it('parses phase 6 owner task fields and blocks owner_repair before rollback parity', () => {
+    const details = _testHelpers.ownerTaskPhaseDetails({
+      lifecycle_state: 'awaiting_owner',
+      risk_level: 'L2',
+      execution_task: { kind: 'owner_repair' },
+      repair_capability: { available: false, mode: 'blocked' },
+      consent_state: { status: 'granted' },
+      rollback_state: { status: 'missing' },
+      prepare_state: { status: 'prepared', prepared: true, prepared_action: 'run_validation_now' },
+    });
+
+    expect(details.lifecycle_state).toBe('awaiting_owner');
+    expect(details.risk_level).toBe('L2');
+    expect(details.execution_task_kind).toBe('owner_repair');
+    expect(details.repair_capability_mode).toBe('blocked');
+    expect(details.consent_status).toBe('granted');
+    expect(details.rollback_status).toBe('missing');
+    expect(details.prepare_status).toBe('prepared');
+    expect(details.requires_rollback_parity_block).toBe(true);
+    expect(details.block_reason).toBe('blocked_pending_rollback_parity');
+  });
+
   it('keeps VERSION aligned with package.json', async () => {
     const repoRoot = path.resolve(__dirname, '..');
     const pkg = JSON.parse(readFileSync(path.join(repoRoot, 'package.json'), 'utf8')) as { version: string };


### PR DESCRIPTION
## Summary
- parse Phase 6 owner task fields in MacAICheck and expose them in owner-check output
- block `execution_task.kind=owner_repair` with `blocked_pending_rollback_parity` before any local execution or owner-verify submission
- add regression tests for the block path and contract parsing, plus README/CHANGELOG sync

## Test Plan
- [x] `npm test -- agent-v2-flow.test.ts`
- [x] `npm test -- aicoevo-contract.test.ts`
- [x] `npm run build`
- [ ] `E:\aicoevo-platform\server\venv\Scripts\python.exe -m pytest tests/test_agent_api_expanded.py -q`

## External Blocker
- Platform regression suite is currently blocked by an existing syntax error in `E:\aicoevo-platform\server\app\services\bounty_service.py:2875`
- Failure observed: `IndentationError: unexpected indent`
- This error is in the dirty platform workspace and is not introduced by this MacAICheck branch