### PR TITLE
feat: block mac owner repair before rollback parity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes will be documented in this file.
 
+## [Unreleased]
+
+### Changed
+
+- 明确 Phase 6 协议约束：MacAICheck 当前只开放 L0/L1 自动验证，`owner_repair` L2 自动修复在 backup/rollback parity 完成前必须阻断。
+- Worker daemon 在收到平台已放行的 `owner_repair` 任务时，会先调用 prepare 接口确认状态，再输出结构化阻断原因，而不是误执行本地修复。
+- 增加 Phase 6 兼容性回归测试，覆盖 legacy `mode` 与 `lifecycle_state` 并存 payload，以及 Mac L2 repair 阻断路径。
+
 ## [1.0.0] - 2026-04-06
 
 ### 首次发布

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,14 +25,13 @@ MacAICheck 是三端生态的 macOS 客户端：
 - 修改上传端点路径 → aicoevo-platform 的路由也要同步
 - 新增扫描器分类 → 同步更新 `web/src/lib/types.ts` 的 `CATEGORY_LABELS`
 
-**WinAICheck 功能对照**: WinAICheck 已实现 37+ 扫描器 + 完整修复系统 + Agent Lite。MacAICheck 当前 18 项检测，修复系统 Phase 1 进行中。
+**WinAICheck 功能对照**: WinAICheck 已实现 37+ 扫描器 + 完整修复系统 + Agent Lite。MacAICheck 当前 18 项检测；Phase 6 协议已支持 L0/L1 自动验证，但 L2 owner repair 仍必须在 backup/rollback parity 完成前保持阻断。
 
-## Current Status (2026-04-12)
+## Current Status (2026-05-03)
 
 - **main 分支**: 稳定可发布
-- **最新 commit**: 7a404aa (CONTRIBUTING major overhaul)
-- **项目阶段**: 初始化完成，Phase 1 待开始
-- **研究方向**: WinAICheck `src/fixers/index.ts` 作为参考实现
+- **项目阶段**: Phase 6 P0 已支持 owner validation 自动验证与 prepare gate；Mac L2 repair parity 仍未开放
+- **研究方向**: 在保持 Win/Platform 协议兼容的前提下，后续再补 backup/rollback parity 与有限 L2 enablement
 
 ## Architecture
 
@@ -70,9 +69,10 @@ src/
 
 ## Current Phase
 
-**Phase 1: Fixer Infrastructure**
-- Fixer 接口 + 注册表 + 错误分类 + 验证闭环
-- 目标：建立核心架构
+**Phase 6 P0: Validation First**
+- 已支持 owner/reviewer 自动验证、prepare gate、execution decision 路由
+- 对 `owner_repair` 的 L2 请求必须显式阻断，直到 Mac backup/rollback parity 完成
+- 后续 P1 再补受限 L2 repair enablement
 
 ## Repository
 

--- a/README.md
+++ b/README.md
@@ -142,6 +142,13 @@ bash scripts/openclaw-smoke.sh
 - OpenClaw 使用 shell hook 写入 `~/.zshrc` / `~/.bashrc` / `~/.bash_profile`。
 - 悬赏命令需要先运行 `mac-aicheck agent bind` 获取 Agent API Key。
 
+### Phase 6 协议说明
+
+- MacAICheck 同时兼容 legacy `mode` 和 Phase 6 `lifecycle_state`，但 Phase 6 自动化行为只认服务端返回的 `lifecycle_state`、`risk_level`、`repair_capability`、`consent_state`、`rollback_state`。
+- 当前 MVP 只开放 L0/L1 自动验证；即使平台 payload 返回 `owner_repair` 或 `run_repair_now`，MacAICheck 在 backup/rollback parity 完成前也必须阻断，不执行 L2 自动修复。
+- 旧客户端或缺字段 payload 只能走“验证 / 人工提示”路径，不能默认升级到 L2 自动修复。
+- `L3` 永不静默执行。
+
 ### 上报数据格式
 
 AICO EVO 使用与 WinAICheck 一致的格式：

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -1068,6 +1068,23 @@ function ownerValidationGateDetails(payload: unknown) {
   };
 }
 
+function ownerRepairExecutionTask(item: Record<string, unknown>, prepareData: unknown) {
+  const prepared = prepareData && typeof prepareData === 'object'
+    ? prepareData as Record<string, unknown>
+    : {};
+  const preparedTask = prepared.execution_task && typeof prepared.execution_task === 'object'
+    ? prepared.execution_task as Record<string, unknown>
+    : {};
+  const itemTask = item.execution_task && typeof item.execution_task === 'object'
+    ? item.execution_task as Record<string, unknown>
+    : {};
+  return { ...itemTask, ...preparedTask };
+}
+
+function isOwnerRepairTask(task: Record<string, unknown>) {
+  return String(task.kind || '').trim() === 'owner_repair';
+}
+
 function shouldPromptCurrentMachine(decision: ReturnType<typeof serverExecutionDecision>) {
   return decision.phase === 'owner_verification' && decision.current_profile_is_target !== false;
 }
@@ -1566,6 +1583,10 @@ async function processPendingOwnerVerifications(headers: Record<string, string>,
     const serverDecision = serverExecutionDecision(item, 'owner_verification');
     const promptCurrentMachine = shouldPromptCurrentMachine(serverDecision);
     const routeLabel = formatExecutionRoute(serverDecision);
+    const itemExecutionTask = item.execution_task && typeof item.execution_task === 'object'
+      ? item.execution_task as Record<string, unknown>
+      : {};
+    const itemIsOwnerRepair = isOwnerRepairTask(itemExecutionTask);
     if (serverDecision.decision === 'ask_user_run') {
       if (promptCurrentMachine) {
         process.stdout.write(
@@ -1576,6 +1597,33 @@ async function processPendingOwnerVerifications(headers: Record<string, string>,
           `[Worker] owner-auto 跳过 ${bountyId}/${answerId}: 已路由回原机器${routeLabel ? ` (${routeLabel})` : ''}\n`,
         );
       }
+      skipped++;
+      continue;
+    }
+    if (itemIsOwnerRepair) {
+      if (!serverAutomationReady(item, 'owner_verification')) {
+        process.stdout.write(`[Worker] owner-repair 跳过 ${bountyId}/${answerId}: 平台已标记为 manual-only\n`);
+        skipped++;
+        continue;
+      }
+      const prepareResult = await prepareOwnerValidationTask(headers, answerId);
+      if (prepareResult.status !== 200) {
+        process.stdout.write(`[Worker] owner-repair 跳过 ${bountyId}/${answerId}: 平台 prepare 失败 (${prepareResult.status})\n`);
+        skipped++;
+        continue;
+      }
+      const prepareGate = ownerValidationGateDetails(prepareResult.data);
+      const repairTask = ownerRepairExecutionTask(item, prepareResult.data);
+      if (!prepareGate.prepared) {
+        process.stdout.write(
+          `[Worker] owner-repair 跳过 ${bountyId}/${answerId}: 平台未放行自动修复 (${prepareGate.prepared_action || 'not_prepared'})\n`,
+        );
+        skipped++;
+        continue;
+      }
+      process.stdout.write(
+        `[Worker] owner-repair 跳过 ${bountyId}/${answerId}: MacAICheck 暂未开放 L2 自动修复，需等待 backup/rollback parity (${String(repairTask.risk_level || 'L2')})\n`,
+      );
       skipped++;
       continue;
     }

--- a/tests/agent-v2-flow.test.ts
+++ b/tests/agent-v2-flow.test.ts
@@ -1220,6 +1220,102 @@ describe('worker-on (TASK-091)', () => {
     expect(capture.output).toContain('需要先在网站确认后再运行');
   });
 
+  it('worker daemon blocks Mac L2 owner repair before backup rollback parity', async () => {
+    seedConfig();
+    const requests: string[] = [];
+    let fetchCount = 0;
+    const fetchMock = vi.fn().mockImplementation(async (url: string) => {
+      requests.push(url);
+      fetchCount++;
+      if (fetchCount >= 3) {
+        const cfg = _testHelpers.loadConfig();
+        cfg.workerEnabled = false;
+        _testHelpers.saveConfig(cfg);
+      }
+      if (url.includes('/heartbeat')) return mockResponse({ recommended_bounties: [] });
+      if (url.includes('/status')) {
+        return mockResponse({
+          pending_owner_verifications: [{
+            bounty_id: 'b_mac_repair',
+            answer_id: 'a_mac_repair',
+            title: 'mac repair should block',
+            solution_summary: 'Attempt L2 repair',
+            validation_cmd: 'pytest -q',
+            execution_decision: {
+              phase: 'owner_verification',
+              decision: 'auto_validate',
+              current_profile_is_target: true,
+            },
+            execution_task: {
+              kind: 'owner_repair',
+              risk_level: 'L2',
+              recommended_action: 'run_repair_now',
+              auto_run_allowed: true,
+              validation_cmd: 'pytest -q',
+              repair_capability: {
+                scanner_id: 'npm-mirror',
+                backup_available: true,
+                rollback_available: true,
+              },
+              rollback_state: { available: true },
+              rollback_ready: true,
+            },
+            prepare_state: {
+              prepared: true,
+              prepared_action: 'run_repair_now',
+              consent_state: 'granted',
+              rollback_ready: true,
+            },
+          }],
+        });
+      }
+      if (url.includes('/owner-validation-tasks/prepare')) {
+        return mockResponse({
+          prepared: true,
+          prepared_action: 'run_repair_now',
+          execution_task: {
+            kind: 'owner_repair',
+            risk_level: 'L2',
+            recommended_action: 'run_repair_now',
+            auto_run_allowed: true,
+            repair_capability: {
+              scanner_id: 'npm-mirror',
+              backup_available: true,
+              rollback_available: true,
+            },
+            rollback_state: { available: true },
+            rollback_ready: true,
+          },
+          prepare_state: {
+            prepared: true,
+            prepared_action: 'run_repair_now',
+            consent_state: 'granted',
+            rollback_ready: true,
+          },
+        });
+      }
+      return mockResponse({});
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    const execSpy = vi.fn();
+    (globalThis as {
+      __MAC_AICHECK_TEST_EXEC__?: (command: string) => { exitCode: number; stdout?: string; stderr?: string };
+    }).__MAC_AICHECK_TEST_EXEC__ = (command: string) => {
+      execSpy(command);
+      return { exitCode: 0, stdout: '', stderr: '' };
+    };
+
+    const capture = captureOutput();
+    const code = await agentMain(['worker', 'daemon', '--worker-interval', '10']);
+    capture.spy.mockRestore();
+
+    expect(code).toBe(0);
+    expect(execSpy).not.toHaveBeenCalled();
+    expect(requests.some(url => url.includes('/owner-validation-tasks/prepare'))).toBe(true);
+    expect(requests.some(url => url.includes('/owner-verify'))).toBe(false);
+    expect(capture.output).toContain('MacAICheck 暂未开放 L2 自动修复');
+  });
+
   it('worker daemon skips owner auto validation when platform prepare stays manual only', async () => {
     const home = seedConfig();
     const projectRoot = path.join(home, 'demo-owner-prepare-manual-project');

--- a/tests/aicoevo-contract.test.ts
+++ b/tests/aicoevo-contract.test.ts
@@ -36,6 +36,51 @@ describe('AICOEVO contract alignment', () => {
     expect(_testHelpers.agentApiBase('v1')).toBe('https://aicoevo.net/api/v1/agent');
   });
 
+  it('treats legacy and Phase 6 fields as one compatible payload surface', () => {
+    const payload = {
+      mode: 'community_verified',
+      current_lifecycle_focus: {
+        problem_brief_id: 'pb_001',
+        bounty_id: 'b_001',
+        answer_id: 'a_001',
+        lifecycle_state: 'awaiting_user_consent',
+        risk_level: 'L2',
+        next_action: 'await_owner_verification',
+        next_action_label: '等待发起者复现',
+        requires_user_attention: true,
+      },
+      pending_owner_verifications: [{
+        bounty_id: 'b_001',
+        answer_id: 'a_001',
+        execution_task: {
+          kind: 'owner_repair',
+          risk_level: 'L2',
+          lifecycle_state: 'awaiting_user_consent',
+          repair_capability: {
+            mode: 'reversible_repair',
+            backup_available: true,
+            rollback_available: true,
+          },
+          rollback_state: {
+            status: 'available',
+            available: true,
+            mode: 'automatic',
+          },
+        },
+        prepare_state: {
+          prepared: false,
+          prepared_action: 'manual_confirm_only',
+          consent_state: 'required',
+        },
+      }],
+    };
+
+    expect(payload.mode).toBe('community_verified');
+    expect(payload.current_lifecycle_focus.lifecycle_state).toBe('awaiting_user_consent');
+    expect(payload.pending_owner_verifications[0]?.execution_task.kind).toBe('owner_repair');
+    expect(payload.pending_owner_verifications[0]?.prepare_state.consent_state).toBe('required');
+  });
+
   it('keeps VERSION aligned with package.json', async () => {
     const repoRoot = path.resolve(__dirname, '..');
     const pkg = JSON.parse(readFileSync(path.join(repoRoot, 'package.json'), 'utf8')) as { version: string };


### PR DESCRIPTION
## Summary\n- block Mac owner repair auto-execution until backup/rollback parity is implemented\n- add regression coverage for Phase 6 payload compatibility and L2 repair blocking\n- document the current Mac Phase 6 constraints\n\n## Verification\n- npm test -- agent-v2-flow.test.ts\n- npm test -- aicoevo-contract.test.ts\n- npm run build\n