### PR TITLE
TASK-250 align MacAICheck bind UX with device flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,8 @@ bash scripts/openclaw-smoke.sh
 - Claude Code 使用 `~/.claude/settings.json` 的 SessionStart/PostToolUse hooks。
 - OpenClaw 使用 shell hook 写入 `~/.zshrc` / `~/.bashrc` / `~/.bash_profile`。
 - 悬赏命令需要先运行 `mac-aicheck agent bind` 获取 Agent API Key。
+- `mac-aicheck agent bind` 的主流程会自动打开 AICOEVO 绑定页；如果浏览器里已经登录，只需在网页中点一次确认即可完成绑定。
+- 6 位绑定码仍保留为兼容兜底流程，仅在手动调试或旧客户端场景下使用，例如 `mac-aicheck agent bind --code 123456`。
 - Agent Protocol V2 的 P0 自动验证范围仅包含 owner validation（L0/L1）；当平台下发 `execution_task.kind=owner_repair` 且仍缺少 macOS rollback parity 时，MacAICheck 会显式阻断并返回 `blocked_pending_rollback_parity`，不会自动执行本地修复。
 
 ### 上报数据格式

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -2563,7 +2563,7 @@ export async function main(argv: string[]) {
             );
             if (reqResult.status === 200) {
               const { confirm_url } = reqResult.data as Record<string, unknown>;
-              process.stdout.write(`  ${agent.name}: 请在浏览器确认绑定 ${confirm_url}\n`);
+              process.stdout.write(`  ${agent.name}: 浏览器会打开绑定确认页 ${confirm_url}\n`);
               // Try opening browser
               try {
                 const openCmd = process.platform === 'darwin' ? 'open' : 'xdg-open';
@@ -2709,15 +2709,15 @@ export async function main(argv: string[]) {
     }
 
     const { request_token, confirm_url, expires_in } = reqResult.data as Record<string, unknown>;
-    process.stdout.write(`\n请在浏览器中确认绑定:\n  ${confirm_url}\n\n`);
+    process.stdout.write(`\n浏览器将打开绑定确认页:\n  ${confirm_url}\n\n`);
 
     // Step 2: 尝试自动打开浏览器
     try {
       const openCmd = process.platform === 'darwin' ? 'open' : 'xdg-open';
       execFileSync(openCmd, [confirm_url as string], { timeout: 5000 });
-      process.stdout.write('已自动打开浏览器。\n\n');
+      process.stdout.write('已自动打开浏览器；如果你已经登录 AICOEVO，网页中点一次确认即可完成绑定。\n\n');
     } catch {
-      process.stdout.write('请手动复制上方链接到浏览器中打开。\n\n');
+      process.stdout.write('请手动打开上方链接；如果尚未登录，先登录后再在网页中确认绑定。\n\n');
     }
 
     // Step 3: 轮询等待确认

--- a/tests/agent-v2-flow.test.ts
+++ b/tests/agent-v2-flow.test.ts
@@ -1920,6 +1920,8 @@ describe('worker-on (TASK-091)', () => {
     expect(requests[0]?.url).toContain('agent_type=claude-code');
     expect(requests[0]?.url).toContain('device_id=device-test');
     expect(requests.some(req => req.url.includes('/bind/poll?request_token=req_tok_123'))).toBe(true);
+    expect(capture.output).toContain('浏览器将打开绑定确认页');
+    expect(capture.output).toContain('网页中确认绑定');
     expect(capture.output).toContain('绑定成功');
     expect(capture.output).toContain('Worker 互助循环: 已启动');
     expect(spawn.calls).toHaveLength(1);


### PR DESCRIPTION
## Summary
- update bind CLI copy to describe auto-open browser plus one-click web confirmation as the primary flow
- keep 6-digit code wording only as fallback guidance
- sync README and bind-flow test expectations

## Verification
- npm test -- tests/agent-v2-flow.test.ts
