### PR TITLE
TASK-254: send readable macOS bind device info

### DIFF
--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -40,6 +40,38 @@ function shortHash(v: string) { return sha256(v).slice(0, 16); }
 function nowIso() { return new Date().toISOString(); }
 function today() { return nowIso().slice(0, 10); }
 
+function detectMacDeviceInfo() {
+  const override = (globalThis as {
+    __MAC_AICHECK_TEST_EXEC__?: (command: string, options?: { cwd?: string }) => { exitCode: number; stdout?: string; stderr?: string };
+  }).__MAC_AICHECK_TEST_EXEC__;
+
+  try {
+    const result = override
+      ? override('sw_vers -productVersion')
+      : (() => {
+          const stdout = execFileSync('sw_vers', ['-productVersion'], {
+            encoding: 'utf-8',
+            timeout: 5000,
+            stdio: ['ignore', 'pipe', 'ignore'],
+          });
+          return { exitCode: 0, stdout, stderr: '' };
+        })();
+    const version = String(result.stdout || '').trim();
+    if (result.exitCode === 0 && version) return `macOS ${version}`;
+  } catch {
+    // fall through to Darwin mapping
+  }
+
+  const darwinMajor = Number(process.versions?.darwin?.split('.')[0] || 0);
+  const fallbackMap: Record<number, string> = {
+    24: 'macOS 15',
+    23: 'macOS 14',
+    22: 'macOS 13',
+    21: 'macOS 12',
+  };
+  return fallbackMap[darwinMajor] || 'macOS';
+}
+
 const SENSITIVE_PATTERNS: Array<{ regex: RegExp; replacement: string }> = [
   { regex: /(?:sk-|api[_-]?key[_-]?)([a-zA-Z0-9_-]{20,})/gi, replacement: '<API_KEY>' },
   { regex: /Bearer\s+[a-zA-Z0-9._-]+/gi, replacement: 'Bearer <TOKEN>' },
@@ -2556,7 +2588,7 @@ export async function main(argv: string[]) {
         process.stdout.write(`\n检测到 ${agents.map(a => a.name).join(', ')}\n`);
         for (const agent of agents) {
           try {
-            const deviceInfo = `${hostname()}/${process.platform}`;
+            const deviceInfo = detectMacDeviceInfo();
             const reqResult = await requestJson(
               `${apiBase()}/bind/request?agent_type=${encodeURIComponent(agent.agentType)}&device_info=${encodeURIComponent(deviceInfo)}&device_id=${encodeURIComponent(cfg.deviceId)}`,
               { method: 'POST', timeoutMs: 15000 },
@@ -2692,7 +2724,7 @@ export async function main(argv: string[]) {
 
     // 新流程：OAuth 设备流（自动打开浏览器）
     const agentName = String(args.agent || 'unknown').trim();
-    const deviceInfo = `${hostname()}/${process.platform}`;
+    const deviceInfo = detectMacDeviceInfo();
 
     process.stdout.write('正在发起设备绑定...\n');
 

--- a/tests/agent-v2-flow.test.ts
+++ b/tests/agent-v2-flow.test.ts
@@ -1888,6 +1888,15 @@ describe('worker-on (TASK-091)', () => {
     seedConfig({ authToken: undefined, profileId: null });
     const spawn = createSpawnStub();
     (globalThis as { __MAC_AICHECK_TEST_SPAWN__?: unknown }).__MAC_AICHECK_TEST_SPAWN__ = spawn.spawnImpl;
+    (globalThis as { __MAC_AICHECK_TEST_EXEC__?: unknown }).__MAC_AICHECK_TEST_EXEC__ = (
+      command: string,
+      options?: { cwd?: string }
+    ) => {
+      if (command === 'sw_vers -productVersion') {
+        return { exitCode: 0, stdout: '15.4.1\n', stderr: '' };
+      }
+      return { exitCode: 1, stdout: '', stderr: 'unsupported' };
+    };
 
     const requests: Array<{ url: string; method: string }> = [];
     const fetchMock = vi.fn().mockImplementation(async (url: string, init?: RequestInit) => {
@@ -1919,6 +1928,7 @@ describe('worker-on (TASK-091)', () => {
     expect(requests[0]?.url).toContain('/bind/request?');
     expect(requests[0]?.url).toContain('agent_type=claude-code');
     expect(requests[0]?.url).toContain('device_id=device-test');
+    expect(requests[0]?.url).toContain('device_info=macOS%2015.4.1');
     expect(requests.some(req => req.url.includes('/bind/poll?request_token=req_tok_123'))).toBe(true);
     expect(capture.output).toContain('浏览器将打开绑定确认页');
     expect(capture.output).toContain('网页中确认绑定');
@@ -1927,5 +1937,52 @@ describe('worker-on (TASK-091)', () => {
     expect(spawn.calls).toHaveLength(1);
     expect(_testHelpers.loadConfig().authToken).toBe('ak_device_flow_123');
     expect(_testHelpers.loadConfig().profileId).toBe('prof_device_flow_mac');
+  });
+
+  it('falls back to darwin major mapping when sw_vers is unavailable', async () => {
+    seedConfig({ authToken: undefined, profileId: null });
+    (globalThis as { __MAC_AICHECK_TEST_EXEC__?: unknown }).__MAC_AICHECK_TEST_EXEC__ = () => ({
+      exitCode: 1,
+      stdout: '',
+      stderr: 'missing',
+    });
+    const originalDarwin = process.versions.darwin;
+    Object.defineProperty(process.versions, 'darwin', {
+      configurable: true,
+      value: '24.0.0',
+    });
+
+    const requests: Array<{ url: string; method: string }> = [];
+    const fetchMock = vi.fn().mockImplementation(async (url: string, init?: RequestInit) => {
+      requests.push({ url, method: String(init?.method || 'GET') });
+      if (url.includes('/bind/request')) {
+        return mockResponse({
+          request_token: 'req_tok_fallback',
+          confirm_url: 'https://aicoevo.net/bind?t=req_tok_fallback',
+          expires_in: 9,
+        });
+      }
+      if (url.includes('/bind/poll')) {
+        return mockResponse({
+          status: 'confirmed',
+          api_key: 'ak_device_flow_456',
+          profile_id: 'prof_device_flow_mac_fallback',
+        });
+      }
+      throw new Error(`unexpected fetch ${url}`);
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const capture = captureOutput();
+    const code = await agentMain(['bind', '--agent', 'claude-code']);
+    capture.spy.mockRestore();
+
+    Object.defineProperty(process.versions, 'darwin', {
+      configurable: true,
+      value: originalDarwin,
+    });
+
+    expect(code).toBe(0);
+    expect(requests[0]?.url).toContain('device_info=macOS%2015');
   });
 });


### PR DESCRIPTION
## Summary
- replace raw hostname/platform bind metadata with readable macOS labels
- prefer sw_vers product version and fall back to Darwin major mapping
- add bind-flow coverage for both primary and fallback metadata paths

## Testing
- npm test -- tests/agent-v2-flow.test.ts