### PR TITLE
feat: 添加自动发布流程

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,68 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: write
+
+jobs:
+  test-and-release:
+    runs-on: macos-15
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          registry-url: 'https://registry.npmjs.org'
+
+      - run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Test
+        run: npm test
+
+      - name: Get version
+        id: version
+        run: echo "VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
+
+      - name: Publish to npm
+        run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          name: MacAICheck v${{ steps.version.outputs.VERSION }}
+          body: |
+            macOS AI 开发环境检测工具
+
+            ## 安装方式
+
+            ### npm 全局安装
+            ```bash
+            npm i -g mac-aicheck
+            ```
+
+            ### npx 免安装运行
+            ```bash
+            npx mac-aicheck
+            ```
+
+            ### Docker
+            ```bash
+            docker run -it --rm ghcr.io/gugug168/mac-aicheck:latest
+            ```
+          draft: false
+          prerelease: false


### PR DESCRIPTION
## Summary
- 新增 `.github/workflows/release.yml`：打 tag 后自动执行测试 → 构建 → npm publish → GitHub Release
- 与 WinAICheck 的 release 流程对齐，统一三仓发布体验

## 使用方式
```bash
# 更新 VERSION + package.json 版本号后
git tag v1.0.x
git push origin main --tags
# CI 自动完成测试、npm publish、GitHub Release
```

## 注意事项
- 需要在 GitHub 仓库 Settings → Secrets 中添加 `NPM_TOKEN`（npm access token）
- 设置命令：`gh secret set NPM_TOKEN --body "your-npm-token"`

## Test plan
- [ ] 合并后打一个测试 tag 验证 CI 流程
- [ ] 确认 npm publish 成功
- [ ] 确认 GitHub Release 创建成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)