### PR TITLE
feat: add MacAICheck tool auto reporting and smoke support

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "scan": "node dist/index.js scan",
     "report": "node dist/index.js report",
     "upload": "node dist/index.js upload",
+    "smoke:tool-events": "bash scripts/tool-event-smoke.sh",
     "test": "vitest run",
     "test:watch": "vitest"
   },

--- a/scripts/tool-event-smoke.sh
+++ b/scripts/tool-event-smoke.sh
@@ -1,0 +1,200 @@
+#!/bin/bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+OUTPUT_DIR="${AICHECK_SMOKE_OUTPUT_DIR:-$ROOT_DIR/.tmp/tool-event-smoke}"
+HOME_DIR="$OUTPUT_DIR/home"
+ONLINE_API_BASE="${AICOEVO_API_BASE:-https://www.aicoevo.net/api/v1}"
+OFFLINE_API_BASE="${AICHECK_OFFLINE_API_BASE:-https://offline.invalid/api/v1}"
+WEB_PORT="${AICHECK_SMOKE_WEB_PORT:-17890}"
+SCANNER_ID="${AICHECK_SMOKE_SCANNER_ID:-missing-smoke-fixer-mac}"
+VERIFY_SCRIPT="${AICHECK_VERIFY_SCRIPT:-}"
+
+export HOME="$HOME_DIR"
+mkdir -p "$OUTPUT_DIR" "$HOME_DIR"
+
+function section() {
+  printf '\n[%s] %s\n' "$1" "$2"
+}
+
+function require_macos() {
+  if [[ "$(uname -s)" != "Darwin" ]]; then
+    echo "此脚本只能在 macOS 上运行。" >&2
+    exit 1
+  fi
+}
+
+function build_repo() {
+  section "1/7" "构建 MacAICheck"
+  cd "$ROOT_DIR"
+  npm run build >/dev/null
+}
+
+function write_metadata() {
+  section "2/7" "记录环境信息"
+  {
+    echo "{"
+    echo "  \"date\": \"$(date -u +"%Y-%m-%dT%H:%M:%SZ")\","
+    echo "  \"pwd\": \"$(pwd)\","
+    echo "  \"node\": \"$(node --version)\","
+    echo "  \"npm\": \"$(npm --version)\","
+    echo "  \"git_head\": \"$(git rev-parse HEAD)\","
+    echo "  \"online_api_base\": \"${ONLINE_API_BASE}\","
+    echo "  \"offline_api_base\": \"${OFFLINE_API_BASE}\","
+    echo "  \"web_port\": ${WEB_PORT}"
+    echo "}"
+  } > "$OUTPUT_DIR/metadata.json"
+}
+
+function run_machine_origin() {
+  section "3/7" "触发 machine-origin 自动上报"
+  export AICOEVO_API_BASE="$ONLINE_API_BASE"
+  node "$ROOT_DIR/dist/agent/index.js" report-tool-event \
+    --step claim \
+    --failed-items bounty-claim \
+    --status error \
+    --event-type step_failed \
+    --claim-id live-smoke-mac \
+    --message "claim failed: live smoke" \
+    --content "claim failed for live smoke" \
+    --command-summary "mac-aicheck agent bounty-claim live-smoke-mac" \
+    | tee "$OUTPUT_DIR/machine-origin-report.json"
+}
+
+function run_offline_queue_and_flush() {
+  section "4/7" "触发 offline -> queue -> flush"
+  export AICOEVO_API_BASE="$OFFLINE_API_BASE"
+  node "$ROOT_DIR/dist/agent/index.js" report-tool-event \
+    --step bind \
+    --failed-items bind-request \
+    --status error \
+    --event-type step_failed \
+    --message "bind failed: offline live smoke" \
+    --content "bind failed for offline live smoke" \
+    | tee "$OUTPUT_DIR/offline-response.json" || true
+
+  cp "$HOME_DIR/.mac-aicheck/uploads/tool-feedback-queue.json" "$OUTPUT_DIR/offline-queue-before-flush.json"
+  node - "$HOME_DIR/.mac-aicheck/uploads/tool-feedback-queue.json" "$OUTPUT_DIR/offline-payload.json" <<'NODE'
+const fs = require('node:fs');
+const queuePath = process.argv[2];
+const outputPath = process.argv[3];
+const queue = JSON.parse(fs.readFileSync(queuePath, 'utf8'));
+const queued = queue.find((item) => item && item.state === 'queued' && item.payload);
+if (!queued) {
+  throw new Error('offline queue payload not found');
+}
+fs.writeFileSync(outputPath, JSON.stringify(queued.payload, null, 2) + '\n', 'utf8');
+NODE
+
+  node - "$HOME_DIR/.mac-aicheck/uploads/tool-feedback-queue.json" <<'NODE'
+const fs = require('node:fs');
+const queuePath = process.argv[2];
+const queue = JSON.parse(fs.readFileSync(queuePath, 'utf8'));
+for (const item of queue) {
+  if (item.state === 'queued') item.nextAttemptAt = '2000-01-01T00:00:00.000Z';
+}
+fs.writeFileSync(queuePath, JSON.stringify(queue, null, 2) + '\n', 'utf8');
+NODE
+
+  export AICOEVO_API_BASE="$ONLINE_API_BASE"
+  node "$ROOT_DIR/dist/agent/index.js" sync | tee "$OUTPUT_DIR/offline-flush-response.json" || true
+
+  cp "$HOME_DIR/.mac-aicheck/uploads/tool-feedback-queue.json" "$OUTPUT_DIR/offline-queue-after-flush.json"
+}
+
+function run_web_fix_failure() {
+  section "5/7" "触发 Web /api/fix 失败自动上报"
+  export AICOEVO_API_BASE="$ONLINE_API_BASE"
+  export PORT="$WEB_PORT"
+  local server_log="$OUTPUT_DIR/web-serve.log"
+  : > "$server_log"
+  node "$ROOT_DIR/dist/index.js" --serve >"$server_log" 2>&1 &
+  local server_pid=$!
+
+  cleanup() {
+    kill "$server_pid" >/dev/null 2>&1 || true
+    wait "$server_pid" >/dev/null 2>&1 || true
+  }
+  trap cleanup EXIT
+
+  for _ in $(seq 1 30); do
+    if curl -fsS "http://127.0.0.1:${WEB_PORT}/api/version-check" >/dev/null 2>&1; then
+      break
+    fi
+    sleep 1
+  done
+
+  curl -fsS -X POST \
+    -H 'Content-Type: application/json' \
+    -d "{\"scannerId\":\"${SCANNER_ID}\"}" \
+    "http://127.0.0.1:${WEB_PORT}/api/fix" \
+    | tee "$OUTPUT_DIR/web-fix-response.json" || true
+
+  cp "$HOME_DIR/.mac-aicheck/uploads/tool-feedback-queue.json" "$OUTPUT_DIR/web-queue-after-fix.json" || true
+  node - "$HOME_DIR/.mac-aicheck/uploads/tool-feedback-queue.json" "$SCANNER_ID" "$OUTPUT_DIR/web-fix-payload.json" <<'NODE'
+const fs = require('node:fs');
+const queuePath = process.argv[2];
+const scannerId = process.argv[3];
+const outputPath = process.argv[4];
+if (!fs.existsSync(queuePath)) process.exit(0);
+const queue = JSON.parse(fs.readFileSync(queuePath, 'utf8'));
+const matched = queue.find((item) => {
+  const failedItems = item?.payload?.env_summary?.failed_items;
+  return Array.isArray(failedItems) && failedItems.includes(scannerId);
+});
+if (!matched?.payload) process.exit(0);
+fs.writeFileSync(outputPath, JSON.stringify(matched.payload, null, 2) + '\n', 'utf8');
+NODE
+
+  cleanup
+  trap - EXIT
+}
+
+function run_optional_verifier() {
+  if [[ -z "$VERIFY_SCRIPT" ]]; then
+    return
+  fi
+  if [[ ! -f "$VERIFY_SCRIPT" ]]; then
+    echo "跳过校验：未找到 VERIFY_SCRIPT=$VERIFY_SCRIPT"
+    return
+  fi
+
+  section "6/7" "运行字段校验脚本"
+  python3 "$VERIFY_SCRIPT" "$OUTPUT_DIR/machine-origin-report.json" --expected-product mac-aicheck \
+    | tee "$OUTPUT_DIR/machine-origin-verify.md" || true
+  python3 "$VERIFY_SCRIPT" "$OUTPUT_DIR/offline-payload.json" --expected-product mac-aicheck \
+    | tee "$OUTPUT_DIR/offline-payload-verify.md" || true
+  if [[ -f "$OUTPUT_DIR/web-fix-payload.json" ]]; then
+    python3 "$VERIFY_SCRIPT" "$OUTPUT_DIR/web-fix-payload.json" --expected-product mac-aicheck \
+      | tee "$OUTPUT_DIR/web-fix-payload-verify.md" || true
+  fi
+}
+
+function print_summary() {
+  section "7/7" "完成"
+  echo "输出目录: $OUTPUT_DIR"
+  echo "关键文件:"
+  echo "  - metadata.json"
+  echo "  - machine-origin-report.json"
+  echo "  - machine-origin-verify.md"
+  echo "  - offline-response.json"
+  echo "  - offline-payload.json"
+  echo "  - offline-payload-verify.md"
+  echo "  - offline-queue-before-flush.json"
+  echo "  - offline-flush-response.json"
+  echo "  - offline-queue-after-flush.json"
+  echo "  - web-fix-response.json"
+  echo "  - web-fix-payload.json"
+  echo "  - web-fix-payload-verify.md"
+  echo "  - web-queue-after-fix.json"
+  echo "  - web-serve.log"
+}
+
+require_macos
+build_repo
+write_metadata
+run_machine_origin
+run_offline_queue_and_flush
+run_web_fix_failure
+run_optional_verifier
+print_summary

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -993,10 +993,19 @@ async function flushToolAutoReports() {
   const queue = loadToolFeedbackQueue();
   if (!queue.length) return { flushed: 0, remaining: 0 };
   const nowMs = Date.parse(nowIso());
+  const MAX_QUEUE_SIZE = 200;
+  const FLUSHED_EXPIRY_MS = 7 * 24 * 60 * 60 * 1000;
+  const FAILED_EXPIRY_MS = 30 * 24 * 60 * 60 * 1000;
   let flushed = 0;
   const updated: Array<Record<string, unknown>> = [];
   for (const item of queue) {
-    if (item.state === 'flushed' || item.state === 'failed') {
+    if (item.state === 'flushed') {
+      if (item.flushedAt && (nowMs - Date.parse(String(item.flushedAt))) > FLUSHED_EXPIRY_MS) continue;
+      updated.push(item);
+      continue;
+    }
+    if (item.state === 'failed') {
+      if (item.lastAttemptAt && (nowMs - Date.parse(String(item.lastAttemptAt))) > FAILED_EXPIRY_MS) continue;
       updated.push(item);
       continue;
     }
@@ -1046,8 +1055,9 @@ async function flushToolAutoReports() {
       });
     }
   }
-  saveToolFeedbackQueue(updated);
-  return { flushed, remaining: updated.filter(item => item.state === 'queued').length };
+  const pruned = updated.length > MAX_QUEUE_SIZE ? updated.slice(-MAX_QUEUE_SIZE) : updated;
+  saveToolFeedbackQueue(pruned);
+  return { flushed, remaining: pruned.filter(item => item.state === 'queued').length };
 }
 
 async function requestJson(url: string, init: { method?: string; headers?: Record<string, string>; body?: unknown; timeoutMs?: number } = {}) {

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -8,8 +8,6 @@ import { lookup } from 'node:dns/promises';
 import { isIP } from 'node:net';
 import { getFixers } from '../fixers/index';
 
-const LOCAL_VERSION = process.env.npm_package_version || '1.0.0';
-
 function getHome() { return process.env.HOME || homedir(); }
 function getBaseDir() { return join(getHome(), '.mac-aicheck'); }
 function paths() {
@@ -25,6 +23,7 @@ function paths() {
     workerState: join(base, 'worker-state.json'),
     workerLock: join(base, 'worker.lock'),
     draftOrganizerState: join(base, 'draft-organizer-state.json'),
+    toolFeedbackQueue: join(base, 'uploads', 'tool-feedback-queue.json'),
   };
 }
 function ensureDir(dir: string) { if (!existsSync(dir)) mkdirSync(dir, { recursive: true }); }
@@ -85,10 +84,48 @@ const SENSITIVE_PATTERNS: Array<{ regex: RegExp; replacement: string }> = [
 function sanitizeText(text: string): string { let r = String(text || ''); for (const p of SENSITIVE_PATTERNS) r = r.replace(p.regex, p.replacement); return r; }
 function trimForCapture(text: string): string { const s = sanitizeText(text); return s.length <= 8000 ? s : s.slice(0, 8000) + '\n<TRUNCATED>'; }
 
+function readVersionCandidate(file: string): string | null {
+  try {
+    if (!existsSync(file)) return null;
+    const version = readFileSync(file, 'utf-8').trim();
+    return version || null;
+  } catch {
+    return null;
+  }
+}
+
+function resolveLocalVersion(): string {
+  const envVersion = String(process.env.npm_package_version || '').trim();
+  if (envVersion) return envVersion;
+
+  const p = paths();
+  const versionCandidates = [
+    join(p.base, 'VERSION'),
+    join(p.agentDir, 'VERSION'),
+    join(__dirname, '../../VERSION'),
+  ];
+  for (const candidate of versionCandidates) {
+    const version = readVersionCandidate(candidate);
+    if (version) return version;
+  }
+
+  const cache = readJson<Record<string, unknown>>(p.versionCache, {});
+  const cachedVersion = typeof cache.macAICheckVersion === 'string' ? cache.macAICheckVersion.trim() : '';
+  if (cachedVersion) return cachedVersion;
+
+  const packageJson = readJson<{ version?: string }>(join(__dirname, '../../package.json'), {});
+  const packageVersion = String(packageJson.version || '').trim();
+  if (packageVersion) return packageVersion;
+
+  return '1.0.0';
+}
+
 // 版本检测和更新检查（参考 gstack）
 const VERSION_CHECK_INTERVAL_MS = 60 * 60 * 1000; // 1 小时限速
 const WORKER_DEFAULT_INTERVAL_MS = 5 * 60 * 1000;
 const WORKER_MAX_PARALLEL = 3;
+const TOOL_REPORT_RETRY_BASE_MS = 30 * 1000;
+const TOOL_REPORT_RETRY_MAX_MS = 30 * 60 * 1000;
 
 interface VersionInfo {
   current: string;
@@ -755,6 +792,11 @@ function isBlockedHost(hostname: string): boolean {
   return false;
 }
 
+function allowPrivateApiBase(): boolean {
+  const raw = String(process.env.MACAICHECK_ALLOW_PRIVATE_API || '').trim().toLowerCase();
+  return raw === '1' || raw === 'true' || raw === 'yes' || raw === 'on';
+}
+
 function apiBase() {
   const configuredBase = [process.env.AICOEVO_API_BASE, process.env.AICOEVO_BASE_URL]
     .find(value => value && !['undefined', 'null'].includes(value.trim().toLowerCase()));
@@ -762,12 +804,14 @@ function apiBase() {
   try {
     const withScheme = raw.startsWith('http') ? raw : `https://${raw}`;
     const parsed = new URL(withScheme);
-    if (isBlockedHost(parsed.hostname)) {
+    if (isBlockedHost(parsed.hostname) && !allowPrivateApiBase()) {
       process.stderr.write(`[安全] AICOEVO_API_BASE 指向内网地址 ${parsed.hostname}，已忽略，使用默认地址\n`);
       return 'https://aicoevo.net/api/v1';
     }
   } catch {}
-  if (!raw.startsWith('https://') && process.env.NODE_ENV !== 'development') return raw.replace(/^http:\/\//, 'https://').endsWith('/api/v1') ? raw.replace(/^http:\/\//, 'https://') : `${raw.replace(/^http:\/\//, 'https://')}/api/v1`;
+  if (!raw.startsWith('https://') && process.env.NODE_ENV !== 'development' && !allowPrivateApiBase()) {
+    return raw.replace(/^http:\/\//, 'https://').endsWith('/api/v1') ? raw.replace(/^http:\/\//, 'https://') : `${raw.replace(/^http:\/\//, 'https://')}/api/v1`;
+  }
   return raw.endsWith('/api/v1') ? raw : `${raw}/api/v1`;
 }
 
@@ -788,9 +832,10 @@ async function resolveHostname(hostname: string): Promise<ResolvedAddress[]> {
 
 async function assertSafeRequestUrl(url: string): Promise<void> {
   const parsed = new URL(url);
-  if (isBlockedHost(parsed.hostname)) {
+  if (isBlockedHost(parsed.hostname) && !allowPrivateApiBase()) {
     throw new Error(`[安全] AICOEVO API 主机 ${parsed.hostname} 属于内网或本机地址，已拒绝请求`);
   }
+  if (allowPrivateApiBase()) return;
   let resolved: ResolvedAddress[];
   try {
     resolved = await resolveHostname(parsed.hostname);
@@ -824,6 +869,187 @@ function agentApiKeyHeaders(config: { authToken?: string }): Record<string, stri
   return { 'X-API-Key': config.authToken };
 }
 
+function buildToolAutoReport(input: {
+  step?: string;
+  status?: string;
+  eventType?: string;
+  failedItems?: string[];
+  failureSignature?: string;
+  statusCode?: number | null;
+  message?: string;
+  content?: string;
+  sessionId?: string | null;
+  claimId?: string | null;
+  commandSummary?: string[];
+  requiresUserConfirmation?: boolean;
+  rollbackStatus?: string | null;
+}) {
+  const config = loadConfig();
+  const product = 'mac-aicheck';
+  const step = String(input.step || '').trim() || 'manual_handoff';
+  const status = String(input.status || '').trim() || 'error';
+  const eventType = String(input.eventType || '').trim() || 'step_failed';
+  const failedItems = uniqueStrings((input.failedItems || []).map(item => String(item || '').trim()).filter(Boolean));
+  const statusCode = Number.isFinite(input.statusCode) ? Number(input.statusCode) : null;
+  const failureSignature = String(input.failureSignature || '').trim()
+    || `${product}:${step}:${failedItems[0] || 'unknown'}:${statusCode ?? 'failed'}`;
+  const message = trimForCapture(input.message || '');
+  const envSummary = {
+    product,
+    source: 'tool_auto_report',
+    step,
+    status,
+    event_type: eventType,
+    failure_signature: failureSignature,
+    failed_items: failedItems.length ? failedItems : ['unknown'],
+    tool_version: resolveLocalVersion(),
+    platform_os: detectMacDeviceInfo(),
+    device_id: String(config.deviceId || '').trim() || undefined,
+    session_id: input.sessionId ? String(input.sessionId).trim() : undefined,
+    claim_id: input.claimId ? String(input.claimId).trim() : undefined,
+    message: message || undefined,
+    command_summary: (input.commandSummary || []).map(item => trimForCapture(String(item || ''))).filter(Boolean),
+    requires_user_confirmation: Boolean(input.requiresUserConfirmation),
+    rollback_status: input.rollbackStatus ? String(input.rollbackStatus).trim() : undefined,
+    created_at: nowIso(),
+  };
+  return {
+    content: trimForCapture(input.content || message || `${step} failed`),
+    category: 'repair_loop',
+    env_summary: Object.fromEntries(Object.entries(envSummary).filter(([, value]) => value !== undefined && value !== null && value !== '')),
+  };
+}
+
+async function reportToolAutoEvent(input: Parameters<typeof buildToolAutoReport>[0]) {
+  const payload = buildToolAutoReport(input);
+  try {
+    const response = await requestJson(`${apiBase()}/feedback`, {
+      method: 'POST',
+      body: payload,
+    });
+    if (response.status >= 200 && response.status < 300) {
+      return { ...response, payload };
+    }
+    queueToolAutoReport(payload, {
+      status: response.status,
+      error: String((response.data as Record<string, unknown>)?.detail || (response.data as Record<string, unknown>)?._raw || `status ${response.status}`),
+      mode: response.status >= 400 && response.status < 500 && response.status !== 429 ? 'failed' : 'queued',
+    });
+    return { ...response, payload };
+  } catch {
+    queueToolAutoReport(payload, {
+      status: 0,
+      error: 'tool auto report failed',
+      mode: 'queued',
+    });
+    return { status: 0, data: { detail: 'tool auto report failed' }, payload };
+  }
+}
+
+function loadToolFeedbackQueue(): Array<Record<string, unknown>> {
+  return readJson<Array<Record<string, unknown>>>(paths().toolFeedbackQueue, []);
+}
+
+function saveToolFeedbackQueue(rows: Array<Record<string, unknown>>) {
+  writeJson(paths().toolFeedbackQueue, rows);
+}
+
+function toolReportBackoffMs(attemptCount: number): number {
+  const attempts = Math.max(1, Number(attemptCount) || 1);
+  return Math.min(TOOL_REPORT_RETRY_BASE_MS * (2 ** (attempts - 1)), TOOL_REPORT_RETRY_MAX_MS);
+}
+
+function queueToolAutoReport(
+  payload: Record<string, unknown>,
+  meta: { status: number; error: string; mode: 'queued' | 'failed' },
+) {
+  const queue = loadToolFeedbackQueue();
+  const now = nowIso();
+  const fingerprint = shortHash(JSON.stringify(payload));
+  const existingIndex = queue.findIndex(item => item.fingerprint === fingerprint && item.state !== 'flushed');
+  const previous = existingIndex >= 0 ? queue[existingIndex] as Record<string, unknown> : null;
+  const attemptCount = Number(previous?.attemptCount || 0) + 1;
+  const nextAttemptAt = new Date(Date.parse(now) + toolReportBackoffMs(attemptCount)).toISOString();
+  const next = {
+    id: String(previous?.id || `toolfb_${crypto.randomUUID()}`),
+    fingerprint,
+    payload,
+    state: meta.mode,
+    attemptCount,
+    firstQueuedAt: String(previous?.firstQueuedAt || now),
+    lastAttemptAt: now,
+    nextAttemptAt: meta.mode === 'failed' ? null : nextAttemptAt,
+    lastStatus: meta.status,
+    lastError: meta.error,
+    flushedAt: previous?.flushedAt || null,
+  };
+  if (existingIndex >= 0) queue[existingIndex] = next;
+  else queue.push(next);
+  saveToolFeedbackQueue(queue);
+  return next;
+}
+
+async function flushToolAutoReports() {
+  const queue = loadToolFeedbackQueue();
+  if (!queue.length) return { flushed: 0, remaining: 0 };
+  const nowMs = Date.parse(nowIso());
+  let flushed = 0;
+  const updated: Array<Record<string, unknown>> = [];
+  for (const item of queue) {
+    if (item.state === 'flushed' || item.state === 'failed') {
+      updated.push(item);
+      continue;
+    }
+    if (item.nextAttemptAt && Date.parse(String(item.nextAttemptAt)) > nowMs) {
+      updated.push(item);
+      continue;
+    }
+    try {
+      const response = await requestJson(`${apiBase()}/feedback`, {
+        method: 'POST',
+        body: item.payload,
+      });
+      if (response.status >= 200 && response.status < 300) {
+        updated.push({
+          ...item,
+          state: 'flushed',
+          flushedAt: nowIso(),
+          lastAttemptAt: nowIso(),
+          lastStatus: response.status,
+          lastError: '',
+          nextAttemptAt: null,
+        });
+        flushed += 1;
+        continue;
+      }
+      const terminal = response.status >= 400 && response.status < 500 && response.status !== 429;
+      const attemptCount = Number(item.attemptCount || 0) + 1;
+      updated.push({
+        ...item,
+        state: terminal ? 'failed' : 'queued',
+        attemptCount,
+        lastAttemptAt: nowIso(),
+        lastStatus: response.status,
+        lastError: String((response.data as Record<string, unknown>)?.detail || (response.data as Record<string, unknown>)?._raw || `status ${response.status}`),
+        nextAttemptAt: terminal ? null : new Date(Date.parse(nowIso()) + toolReportBackoffMs(attemptCount)).toISOString(),
+      });
+    } catch {
+      const attemptCount = Number(item.attemptCount || 0) + 1;
+      updated.push({
+        ...item,
+        state: 'queued',
+        attemptCount,
+        lastAttemptAt: nowIso(),
+        lastStatus: 0,
+        lastError: 'tool auto report failed',
+        nextAttemptAt: new Date(Date.parse(nowIso()) + toolReportBackoffMs(attemptCount)).toISOString(),
+      });
+    }
+  }
+  saveToolFeedbackQueue(updated);
+  return { flushed, remaining: updated.filter(item => item.state === 'queued').length };
+}
+
 async function requestJson(url: string, init: { method?: string; headers?: Record<string, string>; body?: unknown; timeoutMs?: number } = {}) {
   await assertSafeRequestUrl(url);
   const resp = await fetch(url, { method: init.method || 'GET', headers: { Accept: 'application/json', ...(init.body ? { 'Content-Type': 'application/json' } : {}), ...(init.headers || {}) }, body: init.body ? JSON.stringify(init.body) : undefined, signal: AbortSignal.timeout(init.timeoutMs || 5000) });
@@ -836,6 +1062,7 @@ async function requestJson(url: string, init: { method?: string; headers?: Recor
 async function syncEvents() {
   const p = paths();
   const config = loadConfig();
+  await flushToolAutoReports();
   if (config.paused) return { ok: false, skipped: true, reason: 'paused' };
   if (!config.shareData) return { ok: false, skipped: true, reason: 'not_authorized' };
   const all = readJsonl(p.outbox) as Array<Record<string, unknown>>;
@@ -846,7 +1073,18 @@ async function syncEvents() {
     if (config.authToken.startsWith('ak_')) { authH['X-API-Key'] = config.authToken; } else { authH['Authorization'] = `Bearer ${config.authToken}`; }
   }
   const remote = await requestJson(`${apiBase()}/agent-events/batch`, { method: 'POST', headers: authH, body: { clientId: config.clientId, deviceId: normalizeDeviceId(String(config.deviceId || '')), events: pending.map(({ syncStatus, ...e }) => e) } });
-  if (remote.status < 200 || remote.status >= 300) return { ok: false, uploaded: 0, status: remote.status };
+  if (remote.status < 200 || remote.status >= 300) {
+    await reportToolAutoEvent({
+      step: 'sync',
+      status: 'error',
+      eventType: 'step_failed',
+      failedItems: ['agent-events-batch'],
+      statusCode: remote.status,
+      message: `sync failed: ${String((remote.data as Record<string, unknown>)?.detail || (remote.data as Record<string, unknown>)?._raw || `status ${remote.status}`)}`,
+      content: `sync failed while uploading agent events (${remote.status})`,
+    });
+    return { ok: false, uploaded: 0, status: remote.status };
+  }
   const pendingIds = new Set(pending.map(e => e.eventId));
   const updated = all.map(e => pendingIds.has(e.eventId) ? { ...e, syncStatus: 'synced', syncedAt: nowIso() } : e);
   writeFileSync(p.outbox, updated.map(e => JSON.stringify(e)).join('\n') + '\n', 'utf-8');
@@ -2525,6 +2763,53 @@ export async function main(argv: string[]) {
     return 0;
   }
   if (command === 'sync') { const result = await syncEvents(); process.stdout.write(JSON.stringify(result) + '\n'); return result.ok || result.skipped ? 0 : 1; }
+
+  if (command === 'report-tool-event') {
+    const step = String(args.step || '').trim();
+    const status = String(args.status || 'error').trim();
+    const eventType = String(args.eventType || args['event-type'] || 'step_failed').trim();
+    const message = String(args.message || '').trim();
+    const content = String(args.content || message || `${step || 'manual_handoff'} failed`).trim();
+    const failureSignature = String(args.failureSignature || args['failure-signature'] || '').trim();
+    const rollbackStatus = String(args.rollbackStatus || args['rollback-status'] || '').trim();
+    const claimId = String(args.claimId || args['claim-id'] || '').trim();
+    const sessionId = String(args.sessionId || args['session-id'] || '').trim();
+    const failedItems = String(args.failedItems || args['failed-items'] || '')
+      .split(',')
+      .map(value => value.trim())
+      .filter(Boolean);
+    const commandSummary = String(args.commandSummary || args['command-summary'] || '')
+      .split('|||')
+      .map(value => value.trim())
+      .filter(Boolean);
+    const statusCodeRaw = String(args.statusCode || args['status-code'] || '').trim();
+    const statusCode = statusCodeRaw ? Number(statusCodeRaw) : undefined;
+    if (!step) {
+      process.stdout.write('用法: mac-aicheck agent report-tool-event --step <step> --failed-items <a,b> [--status error] [--event-type step_failed]\n');
+      return 1;
+    }
+    if (!failedItems.length) {
+      process.stdout.write('report-tool-event 需要至少一个 failed item\n');
+      return 1;
+    }
+    const result = await reportToolAutoEvent({
+      step,
+      status,
+      eventType,
+      failedItems,
+      failureSignature: failureSignature || undefined,
+      statusCode: Number.isFinite(statusCode) ? statusCode : undefined,
+      message,
+      content,
+      claimId: claimId || undefined,
+      sessionId: sessionId || undefined,
+      commandSummary,
+      rollbackStatus: rollbackStatus || undefined,
+      requiresUserConfirmation: String(args.requiresUserConfirmation || args['requires-user-confirmation'] || '').trim() === 'true',
+    });
+    process.stdout.write(JSON.stringify(result) + '\n');
+    return result.status >= 200 && result.status < 300 ? 0 : 1;
+  }
   if (command === 'pause' || command === 'resume') { const cfg = loadConfig(); cfg.paused = command === 'pause'; saveConfig(cfg); process.stdout.write(command === 'pause' ? '已暂停自动上传和 Worker 互助循环。\n' : '已恢复自动上传和 Worker 互助循环。\n'); return 0; }
 
   if (command === 'disable') {
@@ -2585,9 +2870,25 @@ export async function main(argv: string[]) {
         } else if (workerStart.reason === 'missing auth token') {
           process.stdout.write(`  Worker 互助循环: 等待绑定完成后自动启动\n`);
         } else {
+          await reportToolAutoEvent({
+            step: 'enable',
+            status: 'error',
+            eventType: 'step_failed',
+            failedItems: ['worker-start'],
+            message: 'enable worker start failed',
+            content: 'enable failed while starting worker',
+          });
           process.stdout.write(`  Worker 互助循环: 已禁用\n`);
         }
       } catch (e: unknown) {
+        await reportToolAutoEvent({
+          step: 'enable',
+          status: 'error',
+          eventType: 'step_failed',
+          failedItems: ['worker-start'],
+          message: `enable worker start failed: ${(e as Error).message}`,
+          content: 'enable failed while starting worker',
+        });
         process.stdout.write(`  Worker 互助循环: 启动失败 (${(e as Error).message})\n`);
       }
     } else {
@@ -2756,6 +3057,15 @@ export async function main(argv: string[]) {
 
     if (reqResult.status !== 200) {
       const detail = ((reqResult.data as Record<string, unknown>)?.detail as string) || '未知错误';
+      await reportToolAutoEvent({
+        step: 'bind',
+        status: 'error',
+        eventType: 'step_failed',
+        failedItems: ['bind-request'],
+        statusCode: reqResult.status,
+        message: `bind request failed: ${detail}`,
+        content: `bind request failed (${reqResult.status})`,
+      });
       process.stderr.write(`绑定请求失败 (${reqResult.status}): ${detail}\n`);
       return 1;
     }
@@ -2785,6 +3095,15 @@ export async function main(argv: string[]) {
       );
 
       if (pollResult.status !== 200) {
+        await reportToolAutoEvent({
+          step: 'bind',
+          status: 'error',
+          eventType: 'step_failed',
+          failedItems: ['bind-poll'],
+          statusCode: pollResult.status,
+          message: 'bind poll failed or expired',
+          content: `bind poll failed (${pollResult.status})`,
+        });
         process.stderr.write('\n绑定请求已过期，请重新运行 bind 命令。\n');
         return 1;
       }
@@ -2870,7 +3189,7 @@ export async function main(argv: string[]) {
         // Write just-upgraded marker
         const stateDir = join(getBaseDir(), 'state');
         ensureDir(stateDir);
-        writeFileSync(join(stateDir, 'just-upgraded-from'), LOCAL_VERSION);
+        writeFileSync(join(stateDir, 'just-upgraded-from'), resolveLocalVersion());
         // Clear cache
         try { writeFileSync(join(stateDir, 'last-update-check'), '{}'); } catch {}
         try { const sf = join(stateDir, 'update-snoozed'); if (existsSync(sf)) writeFileSync(sf, ''); } catch {}
@@ -3081,12 +3400,39 @@ export async function main(argv: string[]) {
         headers,
         body: envId ? { env_id: envId } : {},
       });
-      if (result.status >= 400) { process.stdout.write(`认领失败: ${JSON.stringify(result.data)}\n`); return 1; }
+      if (result.status >= 400) {
+        await reportToolAutoEvent({
+          step: 'claim',
+          status: 'error',
+          eventType: 'step_failed',
+          failedItems: ['bounty-claim'],
+          statusCode: result.status,
+          claimId: id,
+          message: `claim failed: ${JSON.stringify(result.data)}`,
+          content: `claim failed for bounty ${id}`,
+          commandSummary: [`mac-aicheck agent bounty-claim ${id}`],
+        });
+        process.stdout.write(`认领失败: ${JSON.stringify(result.data)}\n`);
+        return 1;
+      }
       const d = result.data as Record<string, unknown>;
       process.stdout.write(`✓ 认领成功 ${d.bounty_id} (lease ${d.lease_id})\n`);
       if (d.claimed_until) process.stdout.write(`  截止: ${d.claimed_until}\n`);
       if (d.slot_limit) process.stdout.write(`  并行槽位: ${d.slot_limit}\n`);
-    } catch (e: unknown) { process.stdout.write(`认领失败: ${(e as Error).message}\n`); return 1; }
+    } catch (e: unknown) {
+      await reportToolAutoEvent({
+        step: 'claim',
+        status: 'error',
+        eventType: 'step_failed',
+        failedItems: ['bounty-claim'],
+        claimId: id,
+        message: `claim failed: ${(e as Error).message}`,
+        content: `claim failed for bounty ${id}`,
+        commandSummary: [`mac-aicheck agent bounty-claim ${id}`],
+      });
+      process.stdout.write(`认领失败: ${(e as Error).message}\n`);
+      return 1;
+    }
     return 0;
   }
 
@@ -3421,6 +3767,7 @@ export const _testHelpers = {
   agentApiKeyHeaders,
   agentApiBase,
   apiBase,
+  allowPrivateApiBase,
   isBlockedHost,
   assertSafeRequestUrl,
   checkUpdatesWithNotify,
@@ -3435,6 +3782,11 @@ export const _testHelpers = {
   loadDraftOrganizerState,
   saveDraftOrganizerState,
   runDraftOrganizerOnce,
+  buildToolAutoReport,
+  resolveLocalVersion,
+  reportToolAutoEvent,
+  syncEvents,
+  flushToolAutoReports,
 };
 
 if (require.main === module) {

--- a/src/agent/local-state.ts
+++ b/src/agent/local-state.ts
@@ -263,21 +263,22 @@ type ReportToolEventInput = {
 
 export function reportAgentToolEvent(input: ReportToolEventInput): { ok: boolean; output: string; status: AgentStatus } {
   installEmbeddedLocalAgent();
+  const safeArg = (v: string) => v.replace(/[\r\n&|<>^]/g, ' ');
   const args = [
     'report-tool-event',
-    '--step', input.step,
-    '--failed-items', input.failedItems.join(','),
+    '--step', safeArg(input.step),
+    '--failed-items', input.failedItems.map(s => safeArg(s)).join(','),
   ];
-  if (input.status) args.push('--status', input.status);
-  if (input.eventType) args.push('--event-type', input.eventType);
-  if (input.message) args.push('--message', input.message);
-  if (input.content) args.push('--content', input.content);
-  if (input.failureSignature) args.push('--failure-signature', input.failureSignature);
+  if (input.status) args.push('--status', safeArg(input.status));
+  if (input.eventType) args.push('--event-type', safeArg(input.eventType));
+  if (input.message) args.push('--message', safeArg(input.message));
+  if (input.content) args.push('--content', safeArg(input.content));
+  if (input.failureSignature) args.push('--failure-signature', safeArg(input.failureSignature));
   if (Number.isFinite(input.statusCode)) args.push('--status-code', String(input.statusCode));
-  if (input.claimId) args.push('--claim-id', input.claimId);
-  if (input.sessionId) args.push('--session-id', input.sessionId);
-  if (input.commandSummary?.length) args.push('--command-summary', input.commandSummary.join('|||'));
-  if (input.rollbackStatus) args.push('--rollback-status', input.rollbackStatus);
+  if (input.claimId) args.push('--claim-id', safeArg(input.claimId));
+  if (input.sessionId) args.push('--session-id', safeArg(input.sessionId));
+  if (input.commandSummary?.length) args.push('--command-summary', input.commandSummary.map(s => safeArg(s)).join('|||'));
+  if (input.rollbackStatus) args.push('--rollback-status', safeArg(input.rollbackStatus));
   if (input.requiresUserConfirmation) args.push('--requires-user-confirmation', 'true');
 
   try {

--- a/src/agent/local-state.ts
+++ b/src/agent/local-state.ts
@@ -1,11 +1,13 @@
 import { execFileSync } from 'child_process';
-import { existsSync, mkdirSync, readFileSync, writeFileSync, copyFileSync } from 'fs';
+import { existsSync, mkdirSync, readFileSync, writeFileSync, copyFileSync, chmodSync, readdirSync, statSync } from 'fs';
 import { homedir } from 'os';
 import { join } from 'path';
 import { createHash } from 'crypto';
 import type { AgentStatus } from './types';
 
 function getBaseDir(): string {
+  const override = process.env.MAC_AICHECK_AGENT_BASE_DIR;
+  if (override && override.trim()) return override.trim();
   return join(homedir(), '.mac-aicheck');
 }
 
@@ -50,6 +52,42 @@ function getPaths() {
   };
 }
 
+function resolveBundledVersion(): string {
+  const versionCandidates = [
+    join(__dirname, '../../VERSION'),
+    join(process.cwd(), 'VERSION'),
+  ];
+  for (const candidate of versionCandidates) {
+    try {
+      if (!existsSync(candidate)) continue;
+      const version = readFileSync(candidate, 'utf-8').trim();
+      if (version) return version;
+    } catch {
+      // try next candidate
+    }
+  }
+
+  const packageJson = readJson<{ version?: string }>(join(__dirname, '../../package.json'), {});
+  const packageVersion = String(packageJson.version || '').trim();
+  return packageVersion || '1.0.0';
+}
+
+function copyDirRecursive(srcDir: string, destDir: string) {
+  mkdirSync(destDir, { recursive: true });
+  for (const entry of readdirSync(srcDir, { withFileTypes: true })) {
+    const srcPath = join(srcDir, entry.name);
+    const destPath = join(destDir, entry.name);
+    if (entry.isDirectory()) {
+      copyDirRecursive(srcPath, destPath);
+      continue;
+    }
+    copyFileSync(srcPath, destPath);
+    if ((statSync(srcPath).mode & 0o111) !== 0) {
+      chmodSync(destPath, 0o755);
+    }
+  }
+}
+
 function today(): string {
   const now = new Date();
   const y = now.getFullYear();
@@ -83,10 +121,15 @@ function runAgentCommand(args: string[]): string {
 
 function installEmbeddedLocalAgent() {
   const p = getPaths();
+  const version = resolveBundledVersion();
   mkdirSync(p.agentDir, { recursive: true });
   // 从 dist/agent/index.js 复制（已编译，可直接运行）
   const src = join(__dirname, '../agent/index.js');
+  const runtimeDirs = ['fixers', 'executor', 'scanners', 'installers'];
   copyFileSync(src, p.agentJs);
+  for (const dir of runtimeDirs) {
+    copyDirRecursive(join(__dirname, '..', dir), join(p.base, dir));
+  }
   const hash = createHash('sha256').update(readFileSync(p.agentJs, 'utf-8')).digest('hex');
   writeFileSync(
     join(p.agentDir, 'agent-lite.hash.json'),
@@ -100,6 +143,15 @@ function installEmbeddedLocalAgent() {
     '',
   ].join('\n');
   writeFileSync(p.agentCmd, cmd, 'utf-8');
+  chmodSync(p.agentJs, 0o755);
+  chmodSync(p.agentCmd, 0o755);
+  writeFileSync(join(p.base, 'VERSION'), version + '\n', 'utf-8');
+  writeFileSync(join(p.agentDir, 'VERSION'), version + '\n', 'utf-8');
+  writeFileSync(
+    join(p.base, 'version-cache.json'),
+    JSON.stringify({ macAICheckVersion: version }, null, 2) + '\n',
+    'utf-8',
+  );
   return {
     agentDir: p.agentDir,
     agentJs: p.agentJs,
@@ -188,6 +240,58 @@ export function syncAgentEvents(): { ok: boolean; output: string; status: AgentS
     return {
       ok: false,
       output: '',
+      status: getAgentLocalStatus(),
+    };
+  }
+}
+
+type ReportToolEventInput = {
+  step: string;
+  failedItems: string[];
+  status?: string;
+  eventType?: string;
+  message?: string;
+  content?: string;
+  failureSignature?: string;
+  statusCode?: number;
+  claimId?: string;
+  sessionId?: string;
+  commandSummary?: string[];
+  rollbackStatus?: string;
+  requiresUserConfirmation?: boolean;
+};
+
+export function reportAgentToolEvent(input: ReportToolEventInput): { ok: boolean; output: string; status: AgentStatus } {
+  installEmbeddedLocalAgent();
+  const args = [
+    'report-tool-event',
+    '--step', input.step,
+    '--failed-items', input.failedItems.join(','),
+  ];
+  if (input.status) args.push('--status', input.status);
+  if (input.eventType) args.push('--event-type', input.eventType);
+  if (input.message) args.push('--message', input.message);
+  if (input.content) args.push('--content', input.content);
+  if (input.failureSignature) args.push('--failure-signature', input.failureSignature);
+  if (Number.isFinite(input.statusCode)) args.push('--status-code', String(input.statusCode));
+  if (input.claimId) args.push('--claim-id', input.claimId);
+  if (input.sessionId) args.push('--session-id', input.sessionId);
+  if (input.commandSummary?.length) args.push('--command-summary', input.commandSummary.join('|||'));
+  if (input.rollbackStatus) args.push('--rollback-status', input.rollbackStatus);
+  if (input.requiresUserConfirmation) args.push('--requires-user-confirmation', 'true');
+
+  try {
+    const output = runAgentCommand(args);
+    const parsed = JSON.parse(output);
+    return {
+      ok: parsed.status >= 200 && parsed.status < 300,
+      output,
+      status: getAgentLocalStatus(),
+    };
+  } catch (error) {
+    return {
+      ok: false,
+      output: error instanceof Error ? error.message : String(error),
       status: getAgentLocalStatus(),
     };
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@ import { getFixRiskPresentation, sortIssuesByPriority } from './fixers/presentat
 import { calculateScore } from './scoring/calculator';
 import { createPayload, saveLocal, stashData, buildClaimUrl, submitFeedback } from './api/aicoevo-client';
 import { getInstallers, getAllowedCommands } from './installers/index';
-import { getAgentLocalStatus, enableAgentExperience, pauseAgentUploads, syncAgentEvents } from './agent/local-state';
+import { getAgentLocalStatus, enableAgentExperience, pauseAgentUploads, reportAgentToolEvent, syncAgentEvents } from './agent/local-state';
 import { shouldUploadScan } from './cli/options';
 import * as fs from 'fs';
 import * as path from 'path';
@@ -448,9 +448,30 @@ function serveHttp() {
           const result = await fixAll({ dryRun: Boolean(payload.dryRun), scannerIds: [scannerId] });
           const fixEntry = result.results[0];
           if (!fixEntry) {
+            reportAgentToolEvent({
+              step: 'launch',
+              status: 'error',
+              eventType: 'ui_action_failed',
+              failedItems: [scannerId],
+              message: `No fixer available for ${scannerId}`,
+              content: `ui fix action failed for ${scannerId}`,
+              commandSummary: ['POST /api/fix'],
+            });
             res.writeHead(404, { 'Content-Type': 'application/json' });
             res.end(JSON.stringify({ error: `No fixer available for ${scannerId}` }));
             return;
+          }
+
+          if (fixEntry.error || fixEntry.fixResult?.success === false) {
+            reportAgentToolEvent({
+              step: 'launch',
+              status: 'error',
+              eventType: 'ui_action_failed',
+              failedItems: [scannerId],
+              message: String(fixEntry.error || fixEntry.fixResult?.message || 'fix execution failed'),
+              content: `ui fix action failed for ${scannerId}`,
+              commandSummary: ['POST /api/fix'],
+            });
           }
 
           const refreshedResults = await scanAll();
@@ -467,6 +488,15 @@ function serveHttp() {
             results: refreshedResults,
           }));
         } catch (e: any) {
+          reportAgentToolEvent({
+            step: 'launch',
+            status: 'error',
+            eventType: 'ui_action_failed',
+            failedItems: ['unknown-scanner'],
+            message: e?.message || '修复失败',
+            content: 'ui fix action failed',
+            commandSummary: ['POST /api/fix'],
+          });
           res.writeHead(500, { 'Content-Type': 'application/json' });
           res.end(JSON.stringify({ error: e?.message || '修复失败' }));
         }
@@ -635,7 +665,21 @@ function serveHttp() {
 
 async function runScan(serve: boolean, upload: boolean) {
   console.log(`[*] MacAICheck v${VERSION} scanning...\n`);
-  const results = await scanAll();
+  let results;
+  try {
+    results = await scanAll();
+  } catch (error) {
+    reportAgentToolEvent({
+      step: 'scan',
+      status: 'error',
+      eventType: 'step_failed',
+      failedItems: ['scan-all'],
+      message: error instanceof Error ? error.message : String(error),
+      content: 'scan failed while collecting local diagnostics',
+      commandSummary: [serve ? 'mac-aicheck --serve' : upload ? 'mac-aicheck --upload' : 'mac-aicheck'],
+    });
+    throw error;
+  }
   const score = calculateScore(results);
   // 保存本地 + 上报 aicoevo.net 获取认领 token
   const payload = createPayload(results, score);

--- a/tests/agent-enable.test.ts
+++ b/tests/agent-enable.test.ts
@@ -24,6 +24,7 @@ describe('agent enable targets', () => {
   });
 
   async function loadAgentMain(execImpl?: (cmd: string, args?: string[]) => string) {
+    const chmodSync = vi.fn();
     vi.doMock('child_process', () => ({
       execFileSync: vi.fn((cmd: string, args?: string[]) => {
         if (execImpl) return execImpl(cmd, args);
@@ -33,8 +34,15 @@ describe('agent enable targets', () => {
       }),
       spawn: vi.fn(),
     }));
+    vi.doMock('fs', async () => {
+      const actual = await vi.importActual<typeof import('node:fs')>('node:fs');
+      return {
+        ...actual,
+        chmodSync,
+      };
+    });
     const mod = await import('../src/agent/index');
-    return mod.main;
+    return { main: mod.main, chmodSync };
   }
 
   it('enable --target all installs Claude settings hook and OpenClaw shell hook', async () => {
@@ -52,7 +60,7 @@ describe('agent enable targets', () => {
     vi.stubGlobal('fetch', fetchMock);
 
     const stdout = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
-    const main = await loadAgentMain();
+    const { main } = await loadAgentMain();
     const code = await main(['enable', '--target', 'all']);
     stdout.mockRestore();
 
@@ -80,7 +88,7 @@ describe('agent enable targets', () => {
     });
     vi.stubGlobal('fetch', fetchMock);
 
-    const main = await loadAgentMain((cmd, args) => {
+    const { main } = await loadAgentMain((cmd, args) => {
       if (cmd === 'command' && args?.[0] === '-v' && args[1] === 'openclaw') return '/usr/local/bin/openclaw\n';
       if (cmd === 'command' && args?.[0] === '-v' && args[1] === 'claude') throw new Error('not found');
       return '';
@@ -94,5 +102,36 @@ describe('agent enable targets', () => {
     expect(zshrc).not.toContain('function claude');
     expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(fetchMock.mock.calls[0]?.[0]).toContain('agent_type=openclaw');
+  });
+
+  it('enable installs an executable local agent wrapper', async () => {
+    const home = createTempHome();
+    homes.push(home);
+    process.env.HOME = home;
+    process.argv[1] = path.join(process.cwd(), 'src', 'agent', 'index.ts');
+
+    const fetchMock = vi.fn().mockResolvedValue({
+      status: 200,
+      ok: true,
+      json: async () => ({ confirm_url: 'https://aicoevo.net/bind/openclaw' }),
+      text: async () => JSON.stringify({ confirm_url: 'https://aicoevo.net/bind/openclaw' }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { main, chmodSync } = await loadAgentMain((cmd, args) => {
+      if (cmd === 'command' && args?.[0] === '-v' && args[1] === 'openclaw') return '/usr/local/bin/openclaw\n';
+      if (cmd === 'command' && args?.[0] === '-v' && args[1] === 'claude') throw new Error('not found');
+      return '';
+    });
+
+    const code = await main(['enable', '--target', 'openclaw']);
+    expect(code).toBe(0);
+
+    const agentCmd = path.join(home, '.mac-aicheck', 'agent', 'mac-aicheck-agent');
+    const agentJs = path.join(home, '.mac-aicheck', 'agent', 'agent-lite.js');
+    expect(existsSync(agentCmd)).toBe(true);
+    expect(existsSync(agentJs)).toBe(true);
+    expect(chmodSync).toHaveBeenCalledWith(agentJs, 0o755);
+    expect(chmodSync).toHaveBeenCalledWith(agentCmd, 0o755);
   });
 });

--- a/tests/agent-v2-flow.test.ts
+++ b/tests/agent-v2-flow.test.ts
@@ -38,6 +38,7 @@ describe('agent v2 flow', () => {
   const originalHome = process.env.HOME;
   const originalBaseUrl = process.env.AICOEVO_BASE_URL;
   const originalApiBase = process.env.AICOEVO_API_BASE;
+  const originalNpmPackageVersion = process.env.npm_package_version;
 
   afterEach(() => {
     vi.unstubAllGlobals();
@@ -47,6 +48,9 @@ describe('agent v2 flow', () => {
     restoreEnv('HOME', originalHome);
     restoreEnv('AICOEVO_BASE_URL', originalBaseUrl);
     restoreEnv('AICOEVO_API_BASE', originalApiBase);
+    delete process.env.MACAICHECK_ALLOW_PRIVATE_API;
+    if (originalNpmPackageVersion === undefined) delete process.env.npm_package_version;
+    else process.env.npm_package_version = originalNpmPackageVersion;
     for (const home of homes.splice(0)) {
       rmSync(home, { recursive: true, force: true });
     }
@@ -169,6 +173,18 @@ describe('agent v2 flow', () => {
     }
   });
 
+  it('allows private API base when MACAICHECK_ALLOW_PRIVATE_API is enabled', async () => {
+    seedConfig();
+    process.env.AICOEVO_API_BASE = 'http://192.168.1.176:8013/api/v1';
+    process.env.MACAICHECK_ALLOW_PRIVATE_API = '1';
+
+    expect(_testHelpers.allowPrivateApiBase()).toBe(true);
+    expect(_testHelpers.apiBase()).toBe('http://192.168.1.176:8013/api/v1');
+    await expect(_testHelpers.assertSafeRequestUrl('http://192.168.1.176:8013/api/v1/feedback')).resolves.toBeUndefined();
+
+    delete process.env.MACAICHECK_ALLOW_PRIVATE_API;
+  });
+
   it('rejects API hosts that resolve to loopback addresses', async () => {
     seedConfig();
     process.env.AICOEVO_API_BASE = 'http://127.0.0.1.nip.io';
@@ -213,6 +229,189 @@ describe('agent v2 flow', () => {
     const body = JSON.parse(request?.body || '{}') as { deviceId: string; events: Array<{ deviceId: string }> };
     expect(body.deviceId).toBe('device-test');
     expect(body.events[0]?.deviceId).toBe('device-test_cc');
+  });
+
+  it('sync failure auto-reports repair_loop tool event', async () => {
+    const home = seedConfig();
+    const outboxPath = path.join(home, '.mac-aicheck', 'outbox', 'events.jsonl');
+    mkdirSync(path.dirname(outboxPath), { recursive: true });
+    writeFileSync(outboxPath, JSON.stringify({
+      eventId: 'evt_sync_1',
+      clientId: 'client-test',
+      deviceId: 'device-test_cc',
+      source: 'mac-aicheck-lite',
+      agent: 'claude-code',
+      eventType: 'agent_runtime',
+      occurredAt: '2026-04-30T00:00:00Z',
+      fingerprint: 'fp_sync_1',
+      sanitizedMessage: 'sync me',
+      severity: 'error',
+      localContext: { os: 'darwin', shell: '/bin/zsh', node: process.version, cwdHash: 'hash' },
+      syncStatus: 'pending',
+    }) + '\n', 'utf8');
+
+    const requests: Array<{ url: string; body?: string }> = [];
+    const fetchMock = vi.fn().mockImplementation(async (url: string, init?: RequestInit) => {
+      requests.push({ url, body: init?.body ? String(init.body) : undefined });
+      if (url.endsWith('/api/v1/agent-events/batch')) {
+        return mockResponse({ detail: 'service unavailable' }, 503);
+      }
+      if (url.endsWith('/api/v1/feedback')) {
+        const body = JSON.parse(String(init?.body || '{}'));
+        expect(body.env_summary.step).toBe('sync');
+        expect(body.env_summary.event_type).toBe('step_failed');
+        expect(body.env_summary.failed_items).toEqual(['agent-events-batch']);
+        expect(body.env_summary.failure_signature).toBe('mac-aicheck:sync:agent-events-batch:503');
+        expect(body.env_summary.message).toContain('service unavailable');
+        return mockResponse({ status: 'received' });
+      }
+      throw new Error(`unexpected fetch ${url}`);
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const code = await agentMain(['sync']);
+
+    expect(code).toBe(1);
+    expect(requests.some(req => req.url.endsWith('/api/v1/feedback'))).toBe(true);
+  });
+
+  it('tool auto report network failure queues locally with redaction', async () => {
+    const home = seedConfig();
+    const fetchMock = vi.fn().mockRejectedValue(new Error('offline'));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await _testHelpers.reportToolAutoEvent({
+      step: 'bind',
+      status: 'error',
+      eventType: 'step_failed',
+      failedItems: ['bind-request'],
+      message: 'bind failed at /Users/alice/repo with OPENAI_API_KEY=sk-secret-12345678',
+      content: 'bind request failed',
+    });
+
+    const queuePath = path.join(home, '.mac-aicheck', 'uploads', 'tool-feedback-queue.json');
+    const queue = JSON.parse(readFileSync(queuePath, 'utf8'));
+    expect(result.status).toBe(0);
+    expect(queue).toHaveLength(1);
+    expect(queue[0].state).toBe('queued');
+    expect(queue[0].payload.env_summary.message).toContain('/Users/<USER>/repo');
+    expect(queue[0].payload.env_summary.message).not.toContain('sk-secret');
+  });
+
+  it('queued tool auto report flushes later and marks flushed', async () => {
+    const home = seedConfig();
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('offline')));
+    await _testHelpers.reportToolAutoEvent({
+      step: 'sync',
+      status: 'error',
+      eventType: 'step_failed',
+      failedItems: ['agent-events-batch'],
+      message: 'service unavailable',
+      content: 'sync failed',
+    });
+
+    const queuePath = path.join(home, '.mac-aicheck', 'uploads', 'tool-feedback-queue.json');
+    const queued = JSON.parse(readFileSync(queuePath, 'utf8'));
+    queued[0].nextAttemptAt = '2000-01-01T00:00:00.000Z';
+    writeFileSync(queuePath, JSON.stringify(queued, null, 2) + '\n', 'utf8');
+
+    const fetchMock = vi.fn().mockImplementation(async (url: string, init?: RequestInit) => {
+      if (url.endsWith('/api/v1/feedback')) {
+        const body = JSON.parse(String(init?.body || '{}'));
+        expect(body.env_summary.step).toBe('sync');
+        return mockResponse({ status: 'received' });
+      }
+      throw new Error(`unexpected fetch ${url}`);
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const flush = await _testHelpers.flushToolAutoReports();
+    const queue = JSON.parse(readFileSync(queuePath, 'utf8'));
+    expect(flush.flushed).toBe(1);
+    expect(queue[0].state).toBe('flushed');
+  });
+
+  it('tool auto report marks non-retryable 4xx as failed', async () => {
+    const home = seedConfig();
+    const fetchMock = vi.fn().mockResolvedValue(mockResponse({ detail: 'bad request' }, 400));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await _testHelpers.reportToolAutoEvent({
+      step: 'bind',
+      status: 'error',
+      eventType: 'step_failed',
+      failedItems: ['bind-request'],
+      message: 'bad payload',
+      content: 'bind request failed',
+    });
+
+    const queuePath = path.join(home, '.mac-aicheck', 'uploads', 'tool-feedback-queue.json');
+    const queue = JSON.parse(readFileSync(queuePath, 'utf8'));
+    expect(result.status).toBe(400);
+    expect(queue[0].state).toBe('failed');
+    expect(queue[0].lastStatus).toBe(400);
+  });
+
+  it('report-tool-event command uses the shared reporter contract', async () => {
+    seedConfig();
+    const requests: Array<{ url: string; body: any }> = [];
+    const fetchMock = vi.fn().mockImplementation(async (url: string, init?: RequestInit) => {
+      const body = init?.body ? JSON.parse(String(init.body)) : null;
+      requests.push({ url, body });
+      if (url.endsWith('/api/v1/feedback')) return mockResponse({ status: 'received' });
+      throw new Error(`unexpected fetch ${url}`);
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const stdout = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+
+    const code = await agentMain([
+      'report-tool-event',
+      '--step', 'claim',
+      '--failed-items', 'bounty-claim',
+      '--message', 'claim failed',
+      '--claim-id', 'bounty_m1',
+    ]);
+    const output = stdout.mock.calls.map(call => String(call[0])).join('');
+    stdout.mockRestore();
+    const parsed = JSON.parse(output);
+
+    expect(code).toBe(0);
+    expect(requests).toHaveLength(1);
+    expect(requests[0]?.body?.env_summary?.step).toBe('claim');
+    expect(requests[0]?.body?.env_summary?.failed_items).toEqual(['bounty-claim']);
+    expect(requests[0]?.body?.env_summary?.claim_id).toBe('bounty_m1');
+    expect(parsed.payload.env_summary.step).toBe('claim');
+    expect(parsed.payload.env_summary.failed_items).toEqual(['bounty-claim']);
+    expect(parsed.payload.env_summary.claim_id).toBe('bounty_m1');
+    expect(parsed.data.status).toBe('received');
+  });
+
+  it('bounty-claim failure auto-reports claim failure', async () => {
+    seedConfig();
+    const requests: Array<{ url: string; body: any }> = [];
+    const fetchMock = vi.fn().mockImplementation(async (url: string, init?: RequestInit) => {
+      const body = init?.body ? JSON.parse(String(init.body)) : null;
+      requests.push({ url, body });
+      if (url.endsWith('/api/v2/agent/heartbeat')) return mockResponse({ ok: true });
+      if (url.endsWith('/api/v2/agent/bounties/bounty_m1/claim')) {
+        return mockResponse({ detail: 'lease conflict' }, 409);
+      }
+      if (url.endsWith('/api/v1/feedback')) {
+        expect(body.env_summary.step).toBe('claim');
+        expect(body.env_summary.failed_items).toEqual(['bounty-claim']);
+        expect(body.env_summary.claim_id).toBe('bounty_m1');
+        expect(body.env_summary.message).toContain('lease conflict');
+        return mockResponse({ status: 'received' });
+      }
+      throw new Error(`unexpected fetch ${url}`);
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const code = await agentMain(['bounty-claim', 'bounty_m1']);
+
+    expect(code).toBe(1);
+    expect(requests.some(req => req.url.endsWith('/api/v1/feedback'))).toBe(true);
   });
 
   // ── TASK-100: Owner reproduction loop ──
@@ -477,6 +676,19 @@ describe('agent v2 flow', () => {
 
     const cache = JSON.parse(readFileSync(cachePath, 'utf8')) as { notifiedSignature?: string };
     expect(cache.notifiedSignature).toBe('claude-code:1.0.0->1.1.0');
+  });
+
+  it('falls back to local VERSION file when npm_package_version is missing', () => {
+    const home = seedConfig();
+    writeFileSync(path.join(home, '.mac-aicheck', 'VERSION'), '1.0.9\n', 'utf8');
+    delete process.env.npm_package_version;
+
+    expect(_testHelpers.resolveLocalVersion()).toBe('1.0.9');
+    expect(_testHelpers.buildToolAutoReport({
+      step: 'bind',
+      failedItems: ['bind-request'],
+      message: 'bind failed',
+    }).env_summary.tool_version).toBe('1.0.9');
   });
 
   it('treats failed upgrade results as unsuccessful', () => {
@@ -1962,6 +2174,33 @@ describe('worker-on (TASK-091)', () => {
     expect(spawn.calls[0]?.args.join(' ')).toContain('worker daemon');
   });
 
+  it('enable worker start failure auto-reports enable failure', async () => {
+    seedConfig();
+    let feedbackSeen = false;
+    const fetchMock = vi.fn().mockImplementation(async (url: string, init?: RequestInit) => {
+      if (url.endsWith('/api/v1/feedback')) {
+        const body = JSON.parse(String(init?.body || '{}'));
+        expect(body.env_summary.step).toBe('enable');
+        expect(body.env_summary.event_type).toBe('step_failed');
+        expect(body.env_summary.failed_items).toEqual(['worker-start']);
+        feedbackSeen = true;
+        return mockResponse({ status: 'received' });
+      }
+      throw new Error(`unexpected fetch ${url}`);
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    (globalThis as { __MAC_AICHECK_TEST_SPAWN__?: unknown }).__MAC_AICHECK_TEST_SPAWN__ = () => {
+      throw new Error("spawn failed");
+    };
+
+    const capture = captureOutput();
+    const code = await agentMain(['enable', '--target', 'claude-code']);
+    capture.spy.mockRestore();
+
+    expect(code).toBe(0);
+    expect(feedbackSeen).toBe(true);
+  });
+
   it('bind auto-starts worker after token is granted', async () => {
     seedConfig({ authToken: undefined });
     const spawn = createSpawnStub();
@@ -1978,6 +2217,47 @@ describe('worker-on (TASK-091)', () => {
     expect(spawn.calls).toHaveLength(1);
     expect(spawn.calls[0]?.args.join(' ')).toContain('worker daemon');
     expect(_testHelpers.loadConfig().profileId).toBe('prof_mac');
+  });
+
+  it('device-flow bind request failure auto-reports repair_loop tool event', async () => {
+    seedConfig({ authToken: undefined, profileId: null, workerEnabled: false });
+    (globalThis as { __MAC_AICHECK_TEST_EXEC__?: unknown }).__MAC_AICHECK_TEST_EXEC__ = (
+      command: string,
+    ) => {
+      if (command === 'sw_vers -productVersion') {
+        return { exitCode: 0, stdout: '15.4.1\n', stderr: '' };
+      }
+      return { exitCode: 1, stdout: '', stderr: 'unsupported' };
+    };
+
+    const requests: Array<{ url: string; body?: string }> = [];
+    const fetchMock = vi.fn().mockImplementation(async (url: string, init?: RequestInit) => {
+      requests.push({ url, body: init?.body ? String(init.body) : undefined });
+      if (url.includes('/bind/request?')) {
+        return mockResponse({ detail: 'bind service down' }, 500);
+      }
+      if (url.endsWith('/api/v1/feedback')) {
+        const body = JSON.parse(String(init?.body || '{}'));
+        expect(body.category).toBe('repair_loop');
+        expect(body.env_summary.product).toBe('mac-aicheck');
+        expect(body.env_summary.source).toBe('tool_auto_report');
+        expect(body.env_summary.step).toBe('bind');
+        expect(body.env_summary.event_type).toBe('step_failed');
+        expect(body.env_summary.failed_items).toEqual(['bind-request']);
+        expect(body.env_summary.failure_signature).toBe('mac-aicheck:bind:bind-request:500');
+        expect(body.env_summary.tool_version).toBe('1.0.9');
+        return mockResponse({ status: 'received' });
+      }
+      throw new Error(`unexpected fetch ${url}`);
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const capture = captureOutput();
+    const code = await agentMain(['bind', '--agent', 'claude-code']);
+    capture.spy.mockRestore();
+
+    expect(code).toBe(1);
+    expect(requests.some(req => req.url.endsWith('/api/v1/feedback'))).toBe(true);
   });
 
   it('device-flow bind polls profile_id and saves it to config', async () => {


### PR DESCRIPTION
## Summary
- add tool auto-report reporting for bind/sync/repair loop failures
- add persisted local queue handling and embedded runner install fixes
- add lab smoke helper and tests for reporting/enable flow

## Verification
- npx vitest run tests/agent-enable.test.ts tests/agent-v2-flow.test.ts
- npx tsc --noEmit

## Notes
- excludes local smoke artifacts and codex scratch directories