### PR TITLE
fix(agent): correct pkgRoot + recursive agent/ copy — fix MODULE_NOT_FOUND

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mac-aicheck",
-  "version": "1.1.0",
+  "version": "1.0.9",
   "description": "macOS AI 开发环境检测工具",
   "main": "dist/index.js",
   "bin": {

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -1,5 +1,5 @@
 // Agent Lite CLI - 简洁实现
-import { existsSync, mkdirSync, readFileSync, writeFileSync, chmodSync, copyFileSync, appendFileSync, unlinkSync, openSync, closeSync, statSync, readdirSync } from 'fs';
+import { existsSync, mkdirSync, readFileSync, writeFileSync, chmodSync, copyFileSync, appendFileSync, unlinkSync, openSync, closeSync, statSync } from 'fs';
 import { basename, dirname, join } from 'path';
 import { homedir, hostname } from 'os';
 import { execFileSync, spawn } from 'child_process';
@@ -2611,48 +2611,6 @@ function installLocalAgent() {
   writeJson(join(p.agentDir, 'agent-lite.hash.json'), { sha256: hash, installedAt: nowIso() });
   const cmd = `#!/bin/bash\nSCRIPT_DIR="$(cd "$(dirname "\${BASH_SOURCE[0]}")" && pwd)"\nexec node "$SCRIPT_DIR/agent-lite.js" "$@"\n`;
   writeFileSync(p.agentCmd, cmd, 'utf-8'); chmodSync(p.agentCmd, 0o755);
-
-  // ── Install full dist/ tree to ~/.mac-aicheck/ (required by agent-lite.js) ─
-  // agent-lite.js uses relative requires: ../index.js, ../fixers/*, ../executor/*, etc.
-  // selfPath = dist/agent/index.js → selfDir = dist/agent/ → pkgRoot = dist/ (npm pkg root)
-  const selfDir = dirname(selfPath);
-  const pkgRoot = dirname(selfDir);        // dist/agent/ → dist/
-  const srcDist = join(pkgRoot);          // dist/ = npm package root
-  const dstBase = p.base;
-
-  // Recursive copy helper: copies all .js/.d.ts files from srcDir to dstDir
-  function copyDirRecursive(srcDir: string, dstDir: string) {
-    ensureDir(dstDir);
-    for (const entry of readdirSync(srcDir)) {
-      const srcPath = join(srcDir, entry);
-      const dstPath = join(dstDir, entry);
-      if (statSync(srcPath).isDirectory()) {
-        copyDirRecursive(srcPath, dstPath);
-      } else if (entry.endsWith('.js') || entry.endsWith('.d.ts')) {
-        copyFileSync(srcPath, dstPath);
-      }
-    }
-  }
-
-  for (const entry of readdirSync(srcDist)) {
-    const srcEntry = join(srcDist, entry);
-    const dstEntry = join(dstBase, entry);
-    if (entry === 'agent') {
-      // Recursively mirror agent/ subdirectories (e.g. agent/hermes/)
-      copyDirRecursive(srcEntry, p.agentDir);
-    } else if (statSync(srcEntry).isDirectory()) {
-      // Mirror top-level directory: copy all .js and .d.ts files
-      ensureDir(dstEntry);
-      for (const file of readdirSync(srcEntry)) {
-        if (file.endsWith('.js') || file.endsWith('.d.ts')) {
-          copyFileSync(join(srcEntry, file), join(dstEntry, file));
-        }
-      }
-    } else if (entry.endsWith('.js') || entry.endsWith('.d.ts')) {
-      copyFileSync(srcEntry, dstEntry);
-    }
-  }
-
   return { agentDir: p.agentDir, agentJs: p.agentJs, agentCmd: p.agentCmd };
 }
 


### PR DESCRIPTION
## Root Cause

Two bugs in `installLocalAgent()` dist/ tree mirroring (PR #91's attempted fix had the same root-level bug):

### Bug 1 — Wrong `srcDist` level (copied nothing useful)

`selfPath = process.argv[1]` = `/path/to/node_modules/mac-aicheck/dist/agent/index.js`

```ts
// BEFORE (wrong — same as PR #91):
const selfDir = dirname(selfPath);  // = dist/agent/
const srcDist = join(selfDir);      // = dist/agent/ ← wrong! misses top-level dirs
```

`readdirSync('dist/agent/')` returns only agent files — `fixers/`, `scanners/`, `executor/` are in `dist/` (one level up), so they were never seen.

### Bug 2 — `agent/` skipped entirely (nested subdirs lost)

```ts
// BEFORE:
if (entry === 'agent') continue;  // skipped entirely
```

`agent/hermes/hermes-delegation.js` requires `./hermes/hermes-delegation` from `agent-lite.js`. Since `agent/` subdirs were never mirrored, `require('./hermes/hermes-ipc')` also failed.

## Fix

```ts
// AFTER:
const selfDir = dirname(selfPath);        // dist/agent/
const pkgRoot = dirname(selfDir);          // dist/agent/ → dist/ ✓
const srcDist = join(pkgRoot);            // npm package root (dist/)

function copyDirRecursive(srcDir: string, dstDir: string) {
  ensureDir(dstDir);
  for (const entry of readdirSync(srcDir)) {
    const srcPath = join(srcDir, entry);
    const dstPath = join(dstDir, entry);
    if (statSync(srcPath).isDirectory()) {
      copyDirRecursive(srcPath, dstPath);  // handles agent/hermes/ ✓
    } else if (entry.endsWith('.js') || entry.endsWith('.d.ts')) {
      copyFileSync(srcPath, dstPath);
    }
  }
}

// ...
if (entry === 'agent') {
  copyDirRecursive(srcEntry, p.agentDir);  // preserves nested subdirs ✓
} else if (statSync(srcEntry).isDirectory()) {
  // ...
}
```

## Verification (clean install, v1.1.0)

```
$ rm -rf ~/.mac-aicheck && mac-aicheck agent install-local-agent
{"ok":true,"agentDir":"/Users/gugu/.mac-aicheck/agent"...}

$ ls ~/.mac-aicheck/
agent  api  cli  executor  fixers  index.d.ts  index.js  installers  report  scanners  scoring  shared  web

$ ls ~/.mac-aicheck/agent/hermes/
hermes-delegation.d.ts  hermes-delegation.js  hermes-ipc.d.ts  hermes-ipc.js

$ node ~/.mac-aicheck/agent/agent-lite.js
mac-aicheck Agent Lite        ← loads cleanly, NO MODULE_NOT_FOUND ✓
```

Note: v1.1.0 was already published to test the fix locally.