### PR TITLE
fix(scan): native https SSL check + non-blocking upload + enable 11 Mac scanners

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -691,15 +691,21 @@ async function runScan(serve: boolean, upload: boolean) {
     }
 
     if (upload) {
-      stashData(payload)
+      const stashWithTimeout = Promise.race([
+        stashData(payload),
+        new Promise<never>((_, reject) =>
+          setTimeout(() => reject(new Error('上传超时 (10s)')), 10000)
+        ),
+      ]);
+      stashWithTimeout
         .then(({ token, claim_url }) => {
           const claimUrl = claim_url || buildClaimUrl(token);
           console.log('\n[+] 扫描结果已上传，请在浏览器打开认领你的环境报告:');
           console.log(`    ${claimUrl}\n`);
         })
         .catch((err) => {
-          console.error('\n[-] 上传失败:', err instanceof Error ? err.message : String(err));
-          console.error('    扫描结果已保存在本地，请检查网络后重新运行上传\n');
+          console.warn('\n[!] 上传失败（不影响本地结果）:', err instanceof Error ? err.message : String(err));
+          console.warn('    扫描结果已保存在本地，请检查网络后重新运行上传\n');
         });
     } else {
       console.log('[i] 默认不上传扫描结果。使用 --upload 或 mac-aicheck upload 获取认领链接。\n');

--- a/src/scanners/env-path-length.ts
+++ b/src/scanners/env-path-length.ts
@@ -6,7 +6,6 @@ const scanner: Scanner = {
   name: 'PATH 长度检测',
   category: 'system',
   affectsScore: false,
-  defaultEnabled: false,
 
   async scan(): Promise<ScanResult> {
     const pathVar = process.env.PATH || '';

--- a/src/scanners/long-paths.ts
+++ b/src/scanners/long-paths.ts
@@ -26,7 +26,6 @@ const scanner: Scanner = {
   name: '长路径检测',
   category: 'system',
   affectsScore: false,
-  defaultEnabled: false,
 
   async scan(): Promise<ScanResult> {
     const warnLimit = 240;

--- a/src/scanners/mcp-config-health.ts
+++ b/src/scanners/mcp-config-health.ts
@@ -7,7 +7,6 @@ const scanner: Scanner = {
   name: 'MCP 配置健康检测',
   category: 'ai-tools',
   affectsScore: false,
-  defaultEnabled: false,
 
   async scan(): Promise<ScanResult> {
     const config = readJsonCandidate([...getClaudeMcpConfigCandidates(), ...getMcpConfigCandidates()]);

--- a/src/scanners/mirror-sources.ts
+++ b/src/scanners/mirror-sources.ts
@@ -7,7 +7,6 @@ const scanner: Scanner = {
   name: '镜像源配置检测',
   category: 'network',
   affectsScore: false,
-  defaultEnabled: false,
 
   async scan(): Promise<ScanResult> {
     const detail: string[] = [];

--- a/src/scanners/path-chinese.ts
+++ b/src/scanners/path-chinese.ts
@@ -6,7 +6,6 @@ const scanner: Scanner = {
   name: '路径中文字符检测',
   category: 'system',
   affectsScore: false,
-  defaultEnabled: false,
 
   async scan(): Promise<ScanResult> {
     const targets = [process.cwd(), process.env.HOME || '', process.env.SHELL || ''].filter(Boolean);

--- a/src/scanners/path-spaces.ts
+++ b/src/scanners/path-spaces.ts
@@ -6,7 +6,6 @@ const scanner: Scanner = {
   name: '路径空格检测',
   category: 'system',
   affectsScore: false,
-  defaultEnabled: false,
 
   async scan(): Promise<ScanResult> {
     const paths = [process.cwd(), ...(process.env.PATH || '').split(':')].filter(Boolean);

--- a/src/scanners/python-env-alignment.ts
+++ b/src/scanners/python-env-alignment.ts
@@ -14,7 +14,6 @@ const scanner: Scanner = {
   name: 'Python 环境一致性检测',
   category: 'toolchain',
   affectsScore: false,
-  defaultEnabled: false,
 
   async scan(): Promise<ScanResult> {
     if (!hasProjectMarker(PYTHON_PROJECT_MARKERS)) return { id: this.id, name: this.name, category: this.category, status: 'unknown', message: '当前目录未检测到 Python 项目，跳过环境一致性检查' };

--- a/src/scanners/site-reachability.ts
+++ b/src/scanners/site-reachability.ts
@@ -7,7 +7,6 @@ const scanner: Scanner = {
   name: 'AI 站点连通性检测',
   category: 'network',
   affectsScore: false,
-  defaultEnabled: false,
 
   async scan(): Promise<ScanResult> {
     const sites = [

--- a/src/scanners/ssl-certs.ts
+++ b/src/scanners/ssl-certs.ts
@@ -1,6 +1,19 @@
 import type { Scanner, ScanResult } from './types';
-import { runCommand } from '../executor/index';
+import * as https from 'https';
 import { registerScanner } from './registry';
+
+function checkHttpsSite(hostname: string, path: string = '/'): Promise<{ code: string; ok: boolean }> {
+  return new Promise((resolve) => {
+    const req = https.request({ hostname, path, method: 'HEAD', timeout: 5000 }, (res) => {
+      const code = String(res.statusCode || 'FAIL');
+      const ok = code === '200' || code === '301' || code === '302';
+      resolve({ code, ok });
+    });
+    req.on('error', () => resolve({ code: 'FAIL', ok: false }));
+    req.on('timeout', () => { req.destroy(); resolve({ code: 'TIMEOUT', ok: false }); });
+    req.end();
+  });
+}
 
 const scanner: Scanner = {
   id: 'ssl-certs',
@@ -10,19 +23,16 @@ const scanner: Scanner = {
 
   async scan(): Promise<ScanResult> {
     const sites = [
-      { name: 'github.com', url: 'https://github.com' },
-      { name: 'registry.npmjs.org', url: 'https://registry.npmjs.org' },
+      { name: 'github.com', hostname: 'github.com' },
+      { name: 'registry.npmjs.org', hostname: 'registry.npmjs.org' },
     ];
 
-    const checks = sites.map(site => {
-      const result = runCommand(
-        `curl -s --connect-timeout 5 -o /dev/null -w "%{http_code}" ${site.url} 2>/dev/null`,
-        10000,
-      );
-      const code = result.exitCode === 0 ? result.stdout.trim() : 'FAIL';
-      const ok = code === '200' || code === '301' || code === '302';
-      return { ...site, code, ok };
-    });
+    const checks = await Promise.all(
+      sites.map(async (site) => {
+        const result = await checkHttpsSite(site.hostname);
+        return { name: site.name, ...result };
+      })
+    );
 
     const failed = checks.filter(item => !item.ok);
     if (failed.length === 0) {

--- a/src/scanners/temp-space.ts
+++ b/src/scanners/temp-space.ts
@@ -7,7 +7,6 @@ const scanner: Scanner = {
   name: '临时目录磁盘空间检测',
   category: 'system',
   affectsScore: false,
-  defaultEnabled: false,
 
   async scan(): Promise<ScanResult> {
     const tempDir = process.env.TMPDIR || '/tmp';

--- a/src/scanners/terminal-profile-health.ts
+++ b/src/scanners/terminal-profile-health.ts
@@ -10,7 +10,6 @@ const scanner: Scanner = {
   name: 'macOS 终端配置检测',
   category: 'permission',
   affectsScore: false,
-  defaultEnabled: false,
 
   async scan(): Promise<ScanResult> {
     const shell = process.env.SHELL || '';

--- a/src/scanners/unix-commands.ts
+++ b/src/scanners/unix-commands.ts
@@ -7,7 +7,6 @@ const scanner: Scanner = {
   name: 'Unix 命令检测',
   category: 'toolchain',
   affectsScore: false,
-  defaultEnabled: false,
 
   async scan(): Promise<ScanResult> {
     const commands = ['ls', 'grep', 'curl', 'ssh', 'tar', 'awk', 'sed'];


### PR DESCRIPTION
## Summary

P0 修复 + 扫描器扩展，将 mac-aicheck 扫描器从 21 个扩展到 32 个，并修复两个阻塞性问题。

## Changes

### 1. ssl-certs: 改用 Node.js 原生 https 模块
- 移除了对 curl 的依赖（curl 在某些网络环境下会挂起）
- 每个站点检查独立 5s 超时，不会互相影响
- 使用 `Promise.all` 并行检查两个站点

### 2. index.ts: 上传非阻塞
- `stashData()` 加了 10s 超时（`Promise.race`）
- 上传失败从 `console.error` 改为 `console.warn`，不再阻断扫描结果返回

### 3. 启用 11 个 Mac 适用但默认禁用的扫描器
| Scanner | 说明 |
|---------|------|
| path-chinese | 路径中文字符检测 |
| path-spaces | 路径空格检测 |
| mirror-sources | 镜像源配置检测 |
| site-reachability | AI 站点连通性检测 |
| unix-commands | Unix 命令检测 |
| temp-space | 临时目录磁盘空间 |
| env-path-length | PATH 长度检测 |
| long-paths | 长路径检测 |
| mcp-config-health | MCP 配置健康检测 |
| terminal-profile-health | macOS 终端配置 |
| python-env-alignment | Python 环境一致性 |

### 4. Windows 专属扫描器保持禁用
`wsl-version`, `cuda-version`, `gpu-driver`, `virtualization`, `powershell-policy`, `powershell-version`

## Test

```bash
node dist/index.js --json
# → 32 scanners, exit 0, results printed
```

## Before/After

| Metric | Before | After |
|--------|--------|-------|
| Scanners | 21 | 32 |
| Upload block | Yes (infinite) | No (10s timeout + warn) |
| SSL method | curl | Node.js https |
| CLI exit | Hangs 60s+ | Clean exit ~45s |